### PR TITLE
Add logging/setLevel and MCP notification observability

### DIFF
--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -78,6 +78,7 @@ to the client via the `request_sampling()` helper.
 
 ### Logging
 
+- `logging/setLevel`
 - `notifications/message` (server -> client log notification via `send_log_message()`)
 
 ## Capability Settings

--- a/example/run_server.py
+++ b/example/run_server.py
@@ -1,3 +1,28 @@
+"""Example MCP server with notification support for client testing (e.g. Cursor).
+
+Run for HTTP:
+    python run_server.py
+
+Run for Cursor (stdio MCP):
+    python run_server.py --stdio
+
+Cursor ``mcp.json`` example:
+    {
+      "mcpServers": {
+        "py-mcp-example": {
+          "command": "/path/to/.venv/bin/python",
+          "args": ["/path/to/py-mcp/example/run_server.py", "--stdio"]
+        }
+      }
+    }
+
+After connecting the client:
+- Call ``registerBonusTool`` to emit ``notifications/tools/list_changed``
+- Call ``sendLogNotificationTool`` to emit ``notifications/message``
+- Subscribe to ``memo://welcome``, then call ``refreshWelcomeMemo`` for
+  ``notifications/resources/updated``
+"""
+
 import logging
 
 from config import middleware_config
@@ -9,6 +34,9 @@ from pymcp import (
     resource_registry,
     tool_registry,
 )
+from pymcp.registries.registry import get_registry_manager
+from pymcp.runtime.context import RequestContext
+from pymcp.session.notifications import send_log_message
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -46,6 +74,51 @@ def promptEchoTool(prompt: str) -> str:
     return f"You said: {prompt}"
 
 
+@tool_registry.register
+def registerBonusTool(request_context: RequestContext) -> str:
+    """Register bonusTool at runtime and notify clients that the tools list changed."""
+
+    registry = get_registry_manager(request_context.app).get_tool_registry()
+
+    @registry.register(name="bonusTool")
+    def bonusTool(n: int) -> str:
+        """Adds 100 to n."""
+        return str(n + 100)
+
+    return "Registered bonusTool. Connected clients should receive notifications/tools/list_changed."
+
+
+@tool_registry.register
+async def sendLogNotificationTool(message: str, request_context: RequestContext) -> str:
+    """Send a structured log notification (notifications/message) to the connected client."""
+
+    session_id = request_context.session_id
+    if not session_id:
+        return "No session id available for this call."
+
+    sent = await send_log_message(
+        request_context.app,
+        session_id,
+        level="info",
+        logger="example-server",
+        data={"message": message},
+    )
+    if sent:
+        return f"Sent notifications/message: {message}"
+    return (
+        "Log notification was not delivered. Ensure logging is enabled, "
+        "the client completed initialize, and the SSE stream is open."
+    )
+
+
+@tool_registry.register
+def refreshWelcomeMemo(request_context: RequestContext) -> str:
+    """Notify subscribed clients that memo://welcome was updated."""
+
+    get_registry_manager(request_context.app).get_resource_registry().notify_updated("memo://welcome")
+    return "Sent notifications/resources/updated for memo://welcome (subscribed clients only)."
+
+
 @prompt_registry.register(description="Prompt template for release notes.")
 def releaseNotesPrompt(service: str) -> str:
     return f"Draft a short release note for the {service} service."
@@ -61,7 +134,9 @@ def welcomeMemo() -> str:
 
 
 if __name__ == "__main__":
-    from pymcp import run_http_server
+    import sys
+
+    from pymcp import run_http_server, run_stdio_server
 
     app = create_app(
         middleware_config=middleware_config,
@@ -71,7 +146,15 @@ if __name__ == "__main__":
             capabilities=CapabilitySettings(
                 advertise_empty_prompts=False,
                 advertise_empty_resources=False,
+                tools_list_changed=True,
+                prompts_list_changed=True,
+                resources_list_changed=True,
+                logging_enabled=True,
             ),
         ),
     )
-    run_http_server(app, host="0.0.0.0", port=8088)
+
+    if "--stdio" in sys.argv:
+        run_stdio_server(app)
+    else:
+        run_http_server(app, host="0.0.0.0", port=8088)

--- a/pymcp/protocol/logging_levels.py
+++ b/pymcp/protocol/logging_levels.py
@@ -1,0 +1,49 @@
+"""MCP syslog log level helpers (RFC 5424)."""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+MCP_LOG_LEVELS: Final[dict[str, int]] = {
+    "emergency": 0,
+    "alert": 1,
+    "critical": 2,
+    "error": 3,
+    "warning": 4,
+    "notice": 5,
+    "info": 6,
+    "debug": 7,
+}
+
+
+def normalize_log_level(level: str) -> str | None:
+    normalized = level.strip().lower()
+    if normalized in MCP_LOG_LEVELS:
+        return normalized
+    return None
+
+
+def is_valid_log_level(level: str) -> bool:
+    return normalize_log_level(level) is not None
+
+
+def should_send_log(message_level: str, minimum_level: str | None) -> bool:
+    """Return whether ``message_level`` meets the session minimum severity."""
+
+    if minimum_level is None:
+        return True
+
+    normalized_message = normalize_log_level(message_level)
+    normalized_minimum = normalize_log_level(minimum_level)
+    if normalized_message is None or normalized_minimum is None:
+        return True
+    return MCP_LOG_LEVELS[normalized_message] <= MCP_LOG_LEVELS[normalized_minimum]
+
+
+__all__ = [
+    "MCP_LOG_LEVELS",
+    "is_valid_log_level",
+    "normalize_log_level",
+    "should_send_log",
+]

--- a/pymcp/protocol/types.py
+++ b/pymcp/protocol/types.py
@@ -297,6 +297,10 @@ class LoggingMessageNotificationParams(BaseModel):
     data: JSONValue | None = Field(default=None, description="Arbitrary log data")
 
 
+class SetLoggingLevelRequestParams(BaseModel):
+    level: str = Field(..., description="Minimum log level for notifications/message")
+
+
 # ---------------------------------------------------------------------------
 # Completions types (client -> server)
 # ---------------------------------------------------------------------------
@@ -449,6 +453,7 @@ __all__ = [
     "SamplingContentBlock",
     "SamplingToolDefinition",
     "ServerInfo",
+    "SetLoggingLevelRequestParams",
     "Task",
     "TasksListResult",
     "TextContent",

--- a/pymcp/runtime/dispatch.py
+++ b/pymcp/runtime/dispatch.py
@@ -22,6 +22,7 @@ from .types import DispatchContext, DispatchResponse, DispatchResult, JSONObject
 # Side-effect imports register built-in handlers.
 from .handlers import completions as _completions  # noqa: F401
 from .handlers import lifecycle as _lifecycle  # noqa: F401
+from .handlers import logging as _logging  # noqa: F401
 from .handlers import prompts as _prompts  # noqa: F401
 from .handlers import resources as _resources  # noqa: F401
 from .handlers import roots as _roots  # noqa: F401
@@ -123,6 +124,7 @@ class CapabilityGateMiddleware:
         ("resources/", "resources"),
         ("tasks/", "tasks"),
         ("completion/", "completions"),
+        ("logging/", "logging"),
     )
 
     async def __call__(self, ctx: DispatchContext, call_next: DispatchNext) -> DispatchResponse:

--- a/pymcp/runtime/handlers/logging.py
+++ b/pymcp/runtime/handlers/logging.py
@@ -22,7 +22,7 @@ async def handle_logging_set_level(ctx: DispatchContext) -> DispatchResult:
         payload = ctx.payloads().error(
             ctx.rpc_id,
             MCPErrorCode.INVALID_PARAMS,
-            "Invalid params: missing level",
+            "Invalid params: level must be a non-empty string",
         )
         await ctx.maybe_enqueue(payload)
         return make_result(200, json_response=True, payload=payload)

--- a/pymcp/runtime/handlers/logging.py
+++ b/pymcp/runtime/handlers/logging.py
@@ -1,0 +1,46 @@
+"""Logging handlers."""
+
+from __future__ import annotations
+
+from ...protocol.errors import MCPErrorCode
+from ...protocol.logging_levels import normalize_log_level
+from ..types import DispatchContext, DispatchResult, make_result
+from .registry import rpc_method
+
+
+@rpc_method("logging/setLevel")
+async def handle_logging_set_level(ctx: DispatchContext) -> DispatchResult:
+    if not ctx.supports("logging"):
+        payload = ctx.payloads().error(ctx.rpc_id, MCPErrorCode.METHOD_NOT_FOUND, "logging not supported")
+        await ctx.maybe_enqueue(payload)
+        return make_result(200, json_response=True, payload=payload)
+
+    params_value = ctx.data.get("params")
+    params = params_value if isinstance(params_value, dict) else {}
+    raw_level = params.get("level")
+    if not isinstance(raw_level, str) or not raw_level.strip():
+        payload = ctx.payloads().error(
+            ctx.rpc_id,
+            MCPErrorCode.INVALID_PARAMS,
+            "Invalid params: missing level",
+        )
+        await ctx.maybe_enqueue(payload)
+        return make_result(200, json_response=True, payload=payload)
+
+    level = normalize_log_level(raw_level)
+    if level is None:
+        payload = ctx.payloads().error(
+            ctx.rpc_id,
+            MCPErrorCode.INVALID_PARAMS,
+            f"Invalid params: unknown log level '{raw_level}'",
+        )
+        await ctx.maybe_enqueue(payload)
+        return make_result(200, json_response=True, payload=payload)
+
+    ctx.session.log_level = level
+    payload = ctx.payloads().success(ctx.rpc_id, {})
+    await ctx.maybe_enqueue(payload)
+    return make_result(200, json_response=True, payload=payload)
+
+
+__all__ = ["handle_logging_set_level"]

--- a/pymcp/session/notifications.py
+++ b/pymcp/session/notifications.py
@@ -7,7 +7,13 @@ import json
 from fastapi import FastAPI
 
 from ..capabilities.registry import get_server_capabilities
+from ..protocol.logging_levels import normalize_log_level, should_send_log
 from ..registries.registry import get_registry_manager
+from .queueing import (
+    log_notification_skipped,
+    notification_method,
+    record_outbound_notification,
+)
 from .store import get_session_manager
 from .types import Session, SessionState
 
@@ -18,25 +24,40 @@ JSONObject = dict[str, object]
 async def send_notification(session: Session | None, notification: JSONObject) -> bool:
     """Queue a notification for a ready session with an attached stream."""
 
+    method = notification_method(notification)
     if session is None:
+        log_notification_skipped(method=method, reason="missing_session")
         return False
-    if session.lifecycle_state != SessionState.READY or not session.stream_attached:
+    if session.lifecycle_state != SessionState.READY:
+        log_notification_skipped(method=method, session_id=session.session_id, reason="session_not_ready")
+        return False
+    if not session.stream_attached:
+        log_notification_skipped(method=method, session_id=session.session_id, reason="stream_not_attached")
         return False
     await session.queue.put(json.dumps(notification))
+    record_outbound_notification(session, notification)
     return True
 
 
 def enqueue_notification(session: Session | None, notification: JSONObject) -> bool:
     """Queue a notification without blocking for a ready session with an attached stream."""
 
+    method = notification_method(notification)
     if session is None:
+        log_notification_skipped(method=method, reason="missing_session")
         return False
-    if session.lifecycle_state != SessionState.READY or not session.stream_attached:
+    if session.lifecycle_state != SessionState.READY:
+        log_notification_skipped(method=method, session_id=session.session_id, reason="session_not_ready")
+        return False
+    if not session.stream_attached:
+        log_notification_skipped(method=method, session_id=session.session_id, reason="stream_not_attached")
         return False
     try:
         session.queue.put_nowait(json.dumps(notification))
     except Exception:
+        log_notification_skipped(method=method, session_id=session.session_id, reason="queue_unavailable")
         return False
+    record_outbound_notification(session, notification)
     return True
 
 def attach_prompt_list_changed_notifications(app: FastAPI) -> None:
@@ -150,9 +171,25 @@ async def send_log_message(
 ) -> bool:
     """Send ``notifications/message`` (structured log) to the client.
 
-    Only sent when the server advertises the ``logging`` capability.
+    Only sent when the server advertises the ``logging`` capability and the
+    message meets the session minimum log level configured via ``logging/setLevel``.
     """
-    params: JSONObject = {"level": level}
+    logging_caps = get_server_capabilities(app).get_capabilities().get("logging")
+    if not isinstance(logging_caps, dict):
+        return False
+
+    manager = get_session_manager(app)
+    session = manager.get_session(session_id)
+    if session is None:
+        return False
+
+    normalized_level = normalize_log_level(level)
+    if normalized_level is None:
+        normalized_level = level.strip().lower()
+    if not should_send_log(normalized_level, session.log_level):
+        return False
+
+    params: JSONObject = {"level": normalized_level}
     if logger is not None:
         params["logger"] = logger
     if data is not None:
@@ -162,6 +199,4 @@ async def send_log_message(
         "method": "notifications/message",
         "params": params,
     }
-    manager = get_session_manager(app)
-    session = manager.get_session(session_id)
     return await send_notification(session, notification)

--- a/pymcp/session/queueing.py
+++ b/pymcp/session/queueing.py
@@ -3,8 +3,102 @@
 from __future__ import annotations
 
 import asyncio
+import time
+from typing import Any
 
+from ..observability.logging import get_logger
 from .types import Session
+
+
+logger = get_logger(__name__)
+
+_FOLLOW_UP_WINDOW_SECONDS = 60.0
+
+
+def notification_method(notification: dict[str, Any]) -> str:
+    method = notification.get("method")
+    return method if isinstance(method, str) else "<unknown>"
+
+
+def notification_detail(notification: dict[str, Any]) -> str | None:
+    params = notification.get("params")
+    if not isinstance(params, dict):
+        return None
+    uri = params.get("uri")
+    if isinstance(uri, str):
+        return uri
+    return None
+
+
+def expected_client_follow_up(method: str) -> str:
+    return {
+        "notifications/resources/updated": "resources/read or resources/list",
+        "notifications/tools/list_changed": "tools/list",
+        "notifications/prompts/list_changed": "prompts/list",
+        "notifications/resources/list_changed": "resources/list",
+        "notifications/message": "none (informational)",
+        "notifications/progress": "none (informational)",
+        "notifications/tasks/status": "tasks/get or tasks/result",
+    }.get(method, "depends on client")
+
+
+def record_outbound_notification(session: Session, notification: dict[str, Any]) -> None:
+    method = notification_method(notification)
+    detail = notification_detail(notification)
+    session.last_outbound_notification_method = method
+    session.last_outbound_notification_detail = detail
+    session.last_outbound_notification_at = time.monotonic()
+    logger.info(
+        "[MCP] server -> client notification sent method=%s session=%s detail=%s expected_client_follow_up=%s",
+        method,
+        session.session_id,
+        detail or "",
+        expected_client_follow_up(method),
+    )
+
+
+def log_client_follow_up_request(session: Session, *, request_method: str) -> None:
+    previous = session.last_outbound_notification_method
+    previous_at = session.last_outbound_notification_at
+    if not previous or previous_at is None:
+        return
+    elapsed_ms = int((time.monotonic() - previous_at) * 1000)
+    if elapsed_ms > int(_FOLLOW_UP_WINDOW_SECONDS * 1000):
+        return
+    logger.info(
+        "[HTTP][MCP] client follow-up request method=%s session=%s "
+        "after_notification=%s notification_detail=%s elapsed_ms=%s",
+        request_method,
+        session.session_id,
+        previous,
+        session.last_outbound_notification_detail or "",
+        elapsed_ms,
+    )
+
+
+def log_notification_sent(*, method: str, session_id: str) -> None:
+    logger.info("[MCP] server -> client notification sent method=%s session=%s", method, session_id)
+
+
+def log_notification_skipped(
+    *,
+    method: str,
+    reason: str,
+    session_id: str | None = None,
+) -> None:
+    if session_id is None:
+        logger.debug(
+            "[MCP] server -> client notification skipped method=%s reason=%s",
+            method,
+            reason,
+        )
+        return
+    logger.debug(
+        "[MCP] server -> client notification skipped method=%s session=%s reason=%s",
+        method,
+        session_id,
+        reason,
+    )
 
 
 def get_session_outbound_queue(session: Session) -> asyncio.Queue[str]:

--- a/pymcp/session/store.py
+++ b/pymcp/session/store.py
@@ -9,7 +9,13 @@ from typing import Any
 from uuid import uuid4
 
 from .lifecycle import SessionLifecycle
-from .queueing import get_session_outbound_queue, safe_queue_put
+from .queueing import (
+    get_session_outbound_queue,
+    log_notification_skipped,
+    notification_method,
+    record_outbound_notification,
+    safe_queue_put,
+)
 from .types import Session, SessionState
 
 
@@ -251,21 +257,66 @@ class SessionManager:
     def broadcast_resource_update(self, uri: str, notification: dict[str, Any]) -> None:
         """Broadcast a resource update to sessions subscribed to the URI."""
 
+        method = notification_method(notification)
         message = json.dumps(notification)
+        delivered = 0
         for session in self._sessions.values():
-            if session.lifecycle_state != SessionState.READY or not session.stream_attached:
+            if session.lifecycle_state != SessionState.READY:
+                log_notification_skipped(
+                    method=method,
+                    session_id=session.session_id,
+                    reason="session_not_ready",
+                )
                 continue
-            if uri in session.resource_subscriptions:
-                safe_queue_put(get_session_outbound_queue(session), message)
+            if not session.stream_attached:
+                log_notification_skipped(
+                    method=method,
+                    session_id=session.session_id,
+                    reason="stream_not_attached",
+                )
+                continue
+            if uri not in session.resource_subscriptions:
+                log_notification_skipped(
+                    method=method,
+                    session_id=session.session_id,
+                    reason=f"not_subscribed_to_{uri}",
+                )
+                continue
+            if safe_queue_put(get_session_outbound_queue(session), message):
+                record_outbound_notification(session, notification)
+                delivered += 1
+        if delivered == 0:
+            log_notification_skipped(
+                method=method,
+                reason=f"no_subscribed_sessions_for_{uri}",
+            )
 
     def broadcast_notification(self, notification: dict[str, Any]) -> None:
         """Broadcast a notification to all ready sessions with an attached stream."""
 
+        method = notification_method(notification)
         message = json.dumps(notification)
+        delivered = 0
         for session in self._sessions.values():
-            if session.lifecycle_state != SessionState.READY or not session.stream_attached:
+            if session.lifecycle_state != SessionState.READY:
+                log_notification_skipped(
+                    method=method,
+                    session_id=session.session_id,
+                    reason="session_not_ready",
+                )
                 continue
-            safe_queue_put(get_session_outbound_queue(session), message)
+            if not session.stream_attached:
+                log_notification_skipped(
+                    method=method,
+                    session_id=session.session_id,
+                    reason="stream_not_attached",
+                )
+                continue
+            if safe_queue_put(get_session_outbound_queue(session), message):
+                record_outbound_notification(session, notification)
+                delivered += 1
+        if delivered == 0:
+            log_notification_skipped(method=method, reason="no_ready_sessions_with_stream")
 
     async def shutdown(self) -> None:
         """Close all sessions and cancel pending outbound work (server stop)."""

--- a/pymcp/session/types.py
+++ b/pymcp/session/types.py
@@ -44,6 +44,7 @@ class Session:
     pending: dict[str, Any] = field(default_factory=dict)
     request_ids: set[str | int] = field(default_factory=set)
     resource_subscriptions: set[str] = field(default_factory=set)
+    log_level: str | None = None
     pending_requests: dict[str, asyncio.Future[dict[str, Any]]] = field(default_factory=dict)
     pending_elicitations: dict[str, asyncio.Future[dict[str, Any]]] = field(default_factory=dict)
     event_log: EventLog = field(default_factory=EventLog)
@@ -54,6 +55,9 @@ class Session:
     last_acked_event_id: str | None = None
     closed_at: float | None = None
     state_version: int = 0
+    last_outbound_notification_method: str | None = None
+    last_outbound_notification_detail: str | None = None
+    last_outbound_notification_at: float | None = None
 
 
 __all__ = ["Session", "SessionEvent", "SessionState"]

--- a/pymcp/transport/streamable_http.py
+++ b/pymcp/transport/streamable_http.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from asyncio import TimerHandle, get_running_loop
 from uuid import uuid4
@@ -20,6 +21,8 @@ from ..runtime.payloads import (
 )
 from ..observability.logging import get_logger
 from ..session import get_session_store
+from ..session.queueing import log_client_follow_up_request
+from ..session.types import Session
 from ..settings import SUPPORTED_PROTOCOL_VERSIONS
 from .http_common import accept_contains, get_mcp_session_id, try_parse_json_body
 from .shutdown import ensure_shutdown_event, wait_queue_message
@@ -84,22 +87,57 @@ def _post_headers(request: Request, session_id: str) -> dict[str, str]:
     return {"MCP-Session-Id": session_id}
 
 
-def _log_jsonrpc_start(data: dict) -> None:
+def _log_jsonrpc_start(data: dict, session_id: str, session: Session | None = None) -> None:
     method = data.get("method")
     method_name = method if isinstance(method, str) else "<unknown>"
+    if session is not None and method_name != "<unknown>":
+        log_client_follow_up_request(session, request_method=method_name)
     if method_name == "initialize":
-        logger.info("[HTTP][MCP] server state client connection started")
-        logger.info("[HTTP][MCP] server state handshake started")
-    logger.info("[HTTP][MCP] client -> server request received method=%s", method_name)
-    logger.debug("[HTTP][MCP] client -> server request body method=%s body=%s", method_name, data)
+        logger.info(
+            "[HTTP][MCP] server state client connection started session=%s",
+            session_id,
+        )
+        logger.info(
+            "[HTTP][MCP] server state handshake started session=%s",
+            session_id,
+        )
+    logger.info(
+        "[HTTP][MCP] client -> server request received method=%s session=%s",
+        method_name,
+        session_id,
+    )
+    logger.debug(
+        "[HTTP][MCP] client -> server request body method=%s session=%s body=%s",
+        method_name,
+        session_id,
+        data,
+    )
 
 
-def _log_jsonrpc_complete(method_name: str, status: int, payload: dict | None) -> None:
+def _log_jsonrpc_complete(
+    method_name: str,
+    status: int,
+    payload: dict | None,
+    session_id: str,
+) -> None:
     if method_name == "notifications/initialized" and status == 202:
-        logger.info("[HTTP][MCP] server state handshake complete")
+        logger.info(
+            "[HTTP][MCP] server state handshake complete session=%s",
+            session_id,
+        )
     else:
-        logger.info("[HTTP][MCP] server -> client response sent method=%s status=%s", method_name, status)
-        logger.debug("[HTTP][MCP] server -> client response body method=%s body=%s", method_name, payload)
+        logger.info(
+            "[HTTP][MCP] server -> client response sent method=%s status=%s session=%s",
+            method_name,
+            status,
+            session_id,
+        )
+        logger.debug(
+            "[HTTP][MCP] server -> client response body method=%s session=%s body=%s",
+            method_name,
+            session_id,
+            payload,
+        )
 
 
 def _schedule_connection_complete(request: Request, session_id: str) -> None:
@@ -114,7 +152,10 @@ def _schedule_connection_complete(request: Request, session_id: str) -> None:
 
     def _log_complete() -> None:
         handles.pop(session_id, None)
-        logger.info("[HTTP][MCP] server state client connection complete")
+        logger.info(
+            "[HTTP][MCP] server state client connection complete session=%s",
+            session_id,
+        )
 
     handles[session_id] = get_running_loop().call_later(
         _CONNECTION_COMPLETE_IDLE_SECONDS,
@@ -186,8 +227,32 @@ async def _stream_session_events(
                 continue
 
             counter += 1
+            try:
+                payload_data = json.loads(payload)
+                sse_method = payload_data.get("method")
+                if isinstance(sse_method, str):
+                    logger.info(
+                        "[HTTP][MCP] server -> client sse event method=%s session=%s stream=%s event_id=%s",
+                        sse_method,
+                        session_id,
+                        stream_id,
+                        f"{stream_id}:{counter}",
+                    )
+            except json.JSONDecodeError:
+                logger.debug(
+                    "[HTTP][MCP] server -> client sse event session=%s stream=%s event_id=%s non_json_payload=%s",
+                    session_id,
+                    stream_id,
+                    f"{stream_id}:{counter}",
+                    payload,
+                )
             yield _format_sse(payload, event="message", event_id=f"{stream_id}:{counter}")
     finally:
+        logger.info(
+            "[HTTP][MCP] server state sse stream detached session=%s stream=%s",
+            session_id,
+            stream_id,
+        )
         manager.mark_stream_detached(session_id, stream_id)
 
 
@@ -213,6 +278,11 @@ async def mcp_stream(request: Request) -> Response:
         session_id,
         stream_id=stream_id,
         last_event_id=request.headers.get("Last-Event-ID"),
+    )
+    logger.info(
+        "[HTTP][MCP] server state sse stream attached session=%s stream=%s",
+        session_id,
+        stream_id,
     )
     return StreamingResponse(
         _stream_session_events(request, session_id, session, stream_id),
@@ -261,7 +331,7 @@ async def mcp_post(request: Request) -> Response:
             if principal_error is not None:
                 return principal_error
 
-    _log_jsonrpc_start(data)
+    _log_jsonrpc_start(data, session_id, session)
 
     if method_name is None:
         rpc_id = data.get("id")
@@ -277,7 +347,7 @@ async def mcp_post(request: Request) -> Response:
         app=request.app,
         direct_response=True,
     )
-    _log_jsonrpc_complete(method_name, result.status, result.payload)
+    _log_jsonrpc_complete(method_name, result.status, result.payload, session_id)
     _schedule_connection_complete(request, session_id)
     headers = _post_headers(request, session_id)
     if result.payload is None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -55,7 +55,7 @@ def test_default_server_settings_flow_into_initialize_and_root():
 
 def test_streamable_http_route_is_registered():
     app = create_app()
-    paths = {route.path for route in app.routes}
+    paths = {route.path for route in app.routes if hasattr(route, "path")}
     assert "/mcp" in paths
     assert "/sse-cursor" not in paths
     assert "/message" not in paths

--- a/tests/unit/test_logging_levels.py
+++ b/tests/unit/test_logging_levels.py
@@ -1,0 +1,17 @@
+"""Tests for MCP log level helpers."""
+
+from pymcp.protocol.logging_levels import normalize_log_level, should_send_log
+
+
+def test_normalize_log_level():
+    assert normalize_log_level("INFO") == "info"
+    assert normalize_log_level(" Warning ") == "warning"
+    assert normalize_log_level("verbose") is None
+
+
+def test_should_send_log_respects_minimum_level():
+    assert should_send_log("debug", None) is True
+    assert should_send_log("debug", "info") is False
+    assert should_send_log("info", "info") is True
+    assert should_send_log("error", "info") is True
+    assert should_send_log("warning", "error") is False

--- a/tests/unit/test_logging_notifications.py
+++ b/tests/unit/test_logging_notifications.py
@@ -1,16 +1,27 @@
-"""Tests for send_log_message notification helper."""
+"""Tests for logging/setLevel and send_log_message notification helper."""
 
 import json
 
 import pytest
 
 from pymcp import create_app
+from pymcp.runtime.dispatch import process_jsonrpc_message
 from pymcp.session.notifications import send_log_message
 from pymcp.session.store import get_session_manager
 from pymcp.session.types import SessionState
+from pymcp.settings import CapabilitySettings, ServerSettings
 
 
 pytestmark = pytest.mark.anyio
+
+
+def _logging_app():
+    return create_app(
+        middleware_config=None,
+        server_settings=ServerSettings(
+            capabilities=CapabilitySettings(logging_enabled=True),
+        ),
+    )
 
 
 async def _ready_session(app):
@@ -22,8 +33,32 @@ async def _ready_session(app):
     return session
 
 
+async def _initialize_session(app):
+    manager = get_session_manager(app)
+    session = manager.create_session()
+    await process_jsonrpc_message(
+        session.session_id,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-11-25"},
+        },
+        app=app,
+        direct_response=True,
+    )
+    await process_jsonrpc_message(
+        session.session_id,
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        app=app,
+        direct_response=True,
+    )
+    await manager.note_stream_open(session.session_id, stream_id="stream-1")
+    return session
+
+
 async def test_send_log_message_basic():
-    app = create_app(middleware_config=None)
+    app = _logging_app()
     session = await _ready_session(app)
 
     result = await send_log_message(
@@ -40,7 +75,7 @@ async def test_send_log_message_basic():
 
 
 async def test_send_log_message_without_optional_fields():
-    app = create_app(middleware_config=None)
+    app = _logging_app()
     session = await _ready_session(app)
 
     result = await send_log_message(app, session.session_id, level="error")
@@ -54,7 +89,7 @@ async def test_send_log_message_without_optional_fields():
 
 
 async def test_send_log_message_not_sent_to_non_ready_session():
-    app = create_app(middleware_config=None)
+    app = _logging_app()
     manager = get_session_manager(app)
     session = manager.create_session()
     assert session.lifecycle_state == SessionState.WAIT_INIT
@@ -64,9 +99,96 @@ async def test_send_log_message_not_sent_to_non_ready_session():
 
 
 async def test_send_log_message_not_sent_without_stream():
-    app = create_app(middleware_config=None)
+    app = _logging_app()
     session = await _ready_session(app)
     session.stream_attached = False
 
     result = await send_log_message(app, session.session_id, level="info")
     assert result is False
+
+
+async def test_send_log_message_requires_logging_capability():
+    app = create_app(middleware_config=None)
+    session = await _ready_session(app)
+
+    result = await send_log_message(app, session.session_id, level="info")
+    assert result is False
+
+
+async def test_logging_set_level():
+    app = _logging_app()
+    session = await _initialize_session(app)
+
+    response = await process_jsonrpc_message(
+        session.session_id,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "logging/setLevel",
+            "params": {"level": "warning"},
+        },
+        app=app,
+        direct_response=True,
+    )
+    assert response.payload["result"] == {}
+    assert session.log_level == "warning"
+
+
+async def test_logging_set_level_rejects_invalid_level():
+    app = _logging_app()
+    session = await _initialize_session(app)
+
+    response = await process_jsonrpc_message(
+        session.session_id,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "logging/setLevel",
+            "params": {"level": "verbose"},
+        },
+        app=app,
+        direct_response=True,
+    )
+    assert response.payload["error"]["code"] == -32602
+
+
+async def test_logging_set_level_filters_notifications():
+    app = _logging_app()
+    session = await _initialize_session(app)
+
+    await process_jsonrpc_message(
+        session.session_id,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "logging/setLevel",
+            "params": {"level": "error"},
+        },
+        app=app,
+        direct_response=True,
+    )
+
+    assert await send_log_message(app, session.session_id, level="info") is False
+    assert await send_log_message(app, session.session_id, level="error") is True
+
+    raw = session.queue.get_nowait()
+    msg = json.loads(raw)
+    assert msg["params"]["level"] == "error"
+
+
+async def test_logging_set_level_not_supported_when_capability_disabled():
+    app = create_app(middleware_config=None)
+    session = await _initialize_session(app)
+
+    response = await process_jsonrpc_message(
+        session.session_id,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "logging/setLevel",
+            "params": {"level": "info"},
+        },
+        app=app,
+        direct_response=True,
+    )
+    assert response.payload["error"]["code"] == -32601


### PR DESCRIPTION
## Summary
- Implement `logging/setLevel` with RFC 5424 log level filtering for `notifications/message`
- Add outbound notification observability: delivery logging, expected client follow-ups, and SSE event tracing
- Include session IDs in HTTP MCP request/response logs and correlate client follow-up requests after notifications
- Update `example/run_server.py` with notification demo tools and `--stdio` mode for Cursor testing
- Document `logging/setLevel` in runtime surface docs

## Test plan
- [x] `pytest tests/unit/test_logging_levels.py tests/unit/test_logging_notifications.py`
- [x] `pytest tests/unit/test_resource_subscriptions.py tests/unit/test_streamable_http_transport.py`
- [ ] Connect Cursor via streamable HTTP and verify `refreshWelcomeMemo` emits `notifications/resources/updated` on SSE
- [ ] Confirm server logs show notification sent, SSE event, and any client follow-up requests
- [ ] Call `sendLogNotificationTool` after `logging/setLevel` and verify level filtering

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `logging/setLevel` support for managing server log severity per session, including validation and minimum-severity filtering for delivered log messages.
  * Improved notification handling with richer delivery tracking and client follow-up timing.
  * Updated the server example with runtime-registered notification and logging-oriented test flows.

* **Documentation**
  * Updated runtime surface documentation to include the new logging capability.

* **Tests**
  * Added and expanded unit tests for log level utilities and logging notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->