### PR TITLE
Add full tool declaration metadata for tools/list

### DIFF
--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -32,6 +32,31 @@
 - `tools/list`
 - `tools/call`
 
+Tool registration supports optional declaration metadata:
+
+- `title`
+- `outputSchema`
+- `annotations` (`readOnlyHint`, `destructiveHint`, `openWorldHint`, `idempotentHint`)
+- `icons`
+
+Tool handlers may return `structuredContent` alongside `content` blocks in `tools/call` results.
+
+```python
+from pymcp import tool_registry
+
+@tool_registry.register(
+    title="Add numbers",
+    output_schema={"type": "object", "properties": {"sum": {"type": "number"}}},
+    annotations={"readOnlyHint": True, "destructiveHint": False},
+)
+def addNumbersTool(a: float, b: float) -> dict:
+    total = a + b
+    return {
+        "content": [{"type": "text", "text": str(total)}],
+        "structuredContent": {"sum": total},
+    }
+```
+
 ### Prompts
 
 - `prompts/list`

--- a/pymcp/protocol/types.py
+++ b/pymcp/protocol/types.py
@@ -65,8 +65,39 @@ class JSONRPCResponse(BaseModel):
 
 
 class Annotations(BaseModel):
-    """Content annotations placeholder."""
+    """Optional metadata for content blocks and tool results."""
 
+    audience: list[Literal["user", "assistant"]] | None = Field(
+        default=None,
+        description="Intended audience for the content",
+    )
+    priority: float | None = Field(default=None, description="Relative priority (0.0-1.0)")
+    lastModified: str | None = Field(default=None, description="ISO 8601 last modified timestamp")
+
+
+class ToolAnnotations(BaseModel):
+    """Client hints describing how a tool behaves."""
+
+    title: str | None = Field(default=None, description="Human-readable tool title")
+    readOnlyHint: bool | None = Field(default=None, description="Tool does not modify its environment")
+    destructiveHint: bool | None = Field(
+        default=None,
+        description="Tool may perform destructive updates",
+    )
+    openWorldHint: bool | None = Field(
+        default=None,
+        description="Tool may interact with an open-ended external universe",
+    )
+    idempotentHint: bool | None = Field(
+        default=None,
+        description="Repeated calls with the same arguments have no additional effect",
+    )
+
+
+class ToolIcon(BaseModel):
+    src: str = Field(..., description="Icon URI")
+    mimeType: str | None = Field(default=None, description="Optional MIME type")
+    sizes: list[str] | None = Field(default=None, description="Optional size descriptors")
 
 class TextContent(BaseModel):
     type: str = Field(default="text", description="Content type")
@@ -108,7 +139,11 @@ ContentBlock: TypeAlias = TextContent | ImageContent | AudioContent | EmbeddedRe
 
 
 class CallToolResult(BaseModel):
-    content: list[ContentBlock] = Field(..., description="Content blocks")
+    content: list[ContentBlock] = Field(default_factory=list, description="Content blocks")
+    structuredContent: JSONValue | None = Field(
+        default=None,
+        description="Structured tool output when the client supports it",
+    )
     isError: bool = Field(default=False, description="Whether this is an error result")
     annotations: Annotations | None = Field(default=None, description="Optional annotations")
 
@@ -137,10 +172,19 @@ class TasksListResult(BaseModel):
 
 class Tool(BaseModel):
     name: str = Field(..., description="Tool name")
+    title: str | None = Field(default=None, description="Human-readable tool title")
     description: str | None = Field(default=None, description="Tool description")
     inputSchema: JSONObject = Field(..., description="JSON Schema for input parameters")
+    outputSchema: JSONObject | None = Field(
+        default=None,
+        description="JSON Schema for structured tool output",
+    )
+    annotations: ToolAnnotations | None = Field(
+        default=None,
+        description="Optional client hints for tool behavior",
+    )
+    icons: list[ToolIcon] | None = Field(default=None, description="Optional tool icons")
     execution: ToolExecutionConfig | None = Field(default=None, description="Execution metadata")
-    annotations: Annotations | None = Field(default=None, description="Optional annotations")
 
 
 class CallToolRequestParams(BaseModel):
@@ -454,7 +498,9 @@ __all__ = [
     "TextContent",
     "TextResourceContents",
     "Tool",
+    "ToolAnnotations",
     "ToolChoice",
+    "ToolIcon",
     "ToolResultContent",
     "ToolUseContent",
     "ToolsListChangedNotification",

--- a/pymcp/registries/registry.py
+++ b/pymcp/registries/registry.py
@@ -25,6 +25,40 @@ _R = TypeVar("_R", bound=object)
 _ToolFuncT = TypeVar("_ToolFuncT", bound=ToolFunction)
 
 _INTERNAL_TOOL_PARAMS = frozenset({"cancel_token", "task_context", "request_context"})
+ToolAnnotationsInput = dict[str, Any]
+ToolIconsInput = list[dict[str, Any]]
+
+
+def _normalize_tool_annotations(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump(exclude_none=True)
+        if isinstance(dumped, dict) and dumped:
+            return dumped
+    if isinstance(value, dict):
+        normalized = {key: item for key, item in value.items() if item is not None}
+        return normalized or None
+    return None
+
+
+def _normalize_tool_icons(value: Any) -> list[dict[str, Any]] | None:
+    if value is None:
+        return None
+    if not isinstance(value, list) or not value:
+        return None
+    icons: list[dict[str, Any]] = []
+    for item in value:
+        model_dump = getattr(item, "model_dump", None)
+        if callable(model_dump):
+            dumped = model_dump(exclude_none=True)
+            if isinstance(dumped, dict) and dumped.get("src"):
+                icons.append(dumped)
+            continue
+        if isinstance(item, dict) and item.get("src"):
+            icons.append({key: val for key, val in item.items() if val is not None})
+    return icons or None
 
 
 def _normalize_annotation(annotation: Any) -> Any:
@@ -116,6 +150,10 @@ class ToolDefinition:
     function: SyncOrAsyncCallable
     prompt: bool
     execution: ToolExecutionConfig | None = None
+    title: str | None = None
+    output_schema: JSONSchema | None = None
+    annotations: dict[str, Any] | None = None
+    icons: list[dict[str, Any]] | None = None
 
     def to_mcp_payload(self) -> dict[str, Any]:
         payload = {
@@ -123,6 +161,14 @@ class ToolDefinition:
             "description": self.description,
             "inputSchema": self.input_schema,
         }
+        if self.title:
+            payload["title"] = self.title
+        if self.output_schema:
+            payload["outputSchema"] = self.output_schema
+        if self.annotations:
+            payload["annotations"] = dict(self.annotations)
+        if self.icons:
+            payload["icons"] = [dict(icon) for icon in self.icons]
         if self.execution:
             payload["execution"] = dict(self.execution)
         return payload
@@ -201,6 +247,10 @@ class ToolRegistry(_RegistryBase):
         name: str | None = None,
         description: str | None = None,
         execution: ToolExecutionConfig | None = None,
+        title: str | None = None,
+        output_schema: JSONSchema | None = None,
+        annotations: Any = None,
+        icons: Any = None,
     ) -> _ToolFuncT:
         manager = get_current_registry_manager()
         if manager is not None and manager.tool_registry is not self:
@@ -209,6 +259,10 @@ class ToolRegistry(_RegistryBase):
                 name=name,
                 description=description,
                 execution=execution,
+                title=title,
+                output_schema=output_schema,
+                annotations=annotations,
+                icons=icons,
             )
 
         tool_name = name or func.__name__
@@ -220,6 +274,10 @@ class ToolRegistry(_RegistryBase):
             function=func,
             prompt="prompt" in inspect.signature(func).parameters,
             execution=execution,
+            title=title,
+            output_schema=output_schema,
+            annotations=_normalize_tool_annotations(annotations),
+            icons=_normalize_tool_icons(icons),
         )
         self._tools[tool_name] = definition
         self._notify_listeners()
@@ -233,6 +291,10 @@ class ToolRegistry(_RegistryBase):
         name: str | None = None,
         description: str | None = None,
         execution: ToolExecutionConfig | None = None,
+        title: str | None = None,
+        output_schema: JSONSchema | None = None,
+        annotations: Any = None,
+        icons: Any = None,
     ) -> _ToolFuncT:
         ...
 
@@ -244,6 +306,10 @@ class ToolRegistry(_RegistryBase):
         name: str | None = None,
         description: str | None = None,
         execution: ToolExecutionConfig | None = None,
+        title: str | None = None,
+        output_schema: JSONSchema | None = None,
+        annotations: Any = None,
+        icons: Any = None,
     ) -> Callable[[_ToolFuncT], _ToolFuncT]:
         ...
 
@@ -254,6 +320,10 @@ class ToolRegistry(_RegistryBase):
         name: str | None = None,
         description: str | None = None,
         execution: ToolExecutionConfig | None = None,
+        title: str | None = None,
+        output_schema: JSONSchema | None = None,
+        annotations: Any = None,
+        icons: Any = None,
     ) -> Callable[[_ToolFuncT], _ToolFuncT] | _ToolFuncT:
         if func is None:
             return lambda callback: self._register_tool(
@@ -261,12 +331,20 @@ class ToolRegistry(_RegistryBase):
                 name=name,
                 description=description,
                 execution=execution,
+                title=title,
+                output_schema=output_schema,
+                annotations=annotations,
+                icons=icons,
             )
         return self._register_tool(
             func,
             name=name,
             description=description,
             execution=execution,
+            title=title,
+            output_schema=output_schema,
+            annotations=annotations,
+            icons=icons,
         )
 
     def get(self, name: str) -> ToolDefinition | None:
@@ -290,6 +368,10 @@ class ToolRegistry(_RegistryBase):
                 "inputSchema": tool.input_schema,
                 "prompt": tool.prompt,
                 "execution": tool.execution,
+                "title": tool.title,
+                "outputSchema": tool.output_schema,
+                "annotations": tool.annotations,
+                "icons": tool.icons,
             }
         return payload
 

--- a/tests/unit/test_tool_metadata.py
+++ b/tests/unit/test_tool_metadata.py
@@ -1,0 +1,127 @@
+"""Tests for extended tool declaration and result metadata."""
+
+import pytest
+
+from pymcp import create_app
+from pymcp.protocol.types import Tool, ToolAnnotations, ToolIcon
+from pymcp.registry import tool_registry
+from pymcp.runtime.dispatch import process_jsonrpc_message
+
+
+pytestmark = pytest.mark.anyio
+
+
+async def _initialize(app, session_id: str) -> None:
+    await process_jsonrpc_message(
+        session_id,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-06-18"},
+        },
+        app=app,
+        direct_response=True,
+    )
+    await process_jsonrpc_message(
+        session_id,
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        app=app,
+        direct_response=True,
+    )
+
+
+async def test_tools_list_includes_extended_metadata():
+    @tool_registry.register(
+        title="Add numbers",
+        output_schema={
+            "type": "object",
+            "properties": {"sum": {"type": "number"}},
+            "required": ["sum"],
+        },
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "openWorldHint": False,
+            "idempotentHint": True,
+        },
+        icons=[{"src": "https://example.com/add.svg", "mimeType": "image/svg+xml"}],
+    )
+    def metadataDemoTool(a: float, b: float) -> dict[str, object]:
+        """Adds two numbers."""
+        total = a + b
+        return {
+            "content": [{"type": "text", "text": str(total)}],
+            "structuredContent": {"sum": total},
+        }
+
+    app = create_app(middleware_config=None)
+    session = app.state.session_manager.create_session()
+    await _initialize(app, session.session_id)
+
+    response = await process_jsonrpc_message(
+        session.session_id,
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        app=app,
+        direct_response=True,
+    )
+    tools = response.payload["result"]["tools"]
+    tool = next(item for item in tools if item["name"] == "metadataDemoTool")
+
+    assert tool["title"] == "Add numbers"
+    assert tool["outputSchema"]["properties"]["sum"]["type"] == "number"
+    assert tool["annotations"]["readOnlyHint"] is True
+    assert tool["icons"][0]["src"] == "https://example.com/add.svg"
+
+    validated = Tool.model_validate(tool)
+    assert validated.title == "Add numbers"
+    assert validated.outputSchema is not None
+    assert validated.annotations == ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        openWorldHint=False,
+        idempotentHint=True,
+    )
+    assert validated.icons == [
+        ToolIcon(src="https://example.com/add.svg", mimeType="image/svg+xml"),
+    ]
+
+
+async def test_tools_call_returns_structured_content():
+    @tool_registry.register(
+        output_schema={"type": "object", "properties": {"value": {"type": "string"}}},
+    )
+    def structuredResultTool(value: str) -> dict[str, object]:
+        return {
+            "structuredContent": {"value": value},
+            "content": [{"type": "text", "text": value}],
+        }
+
+    app = create_app(middleware_config=None)
+    session = app.state.session_manager.create_session()
+    await _initialize(app, session.session_id)
+
+    response = await process_jsonrpc_message(
+        session.session_id,
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "structuredResultTool", "arguments": {"value": "hello"}},
+        },
+        app=app,
+        direct_response=True,
+    )
+
+    result = response.payload["result"]
+    assert result["structuredContent"] == {"value": "hello"}
+    assert result["content"][0]["text"] == "hello"
+
+
+def test_tool_definition_omits_empty_optional_fields():
+    @tool_registry.register
+    def plainTool() -> str:
+        return "ok"
+
+    payload = tool_registry.get("plainTool").to_mcp_payload()
+    assert set(payload.keys()) == {"name", "description", "inputSchema"}


### PR DESCRIPTION
## Summary
- Add `ToolAnnotations`, `ToolIcon`, and extended `Tool` protocol fields: `title`, `outputSchema`, `annotations`, and `icons`
- Wire optional metadata through `tool_registry.register()` and `ToolDefinition.to_mcp_payload()`
- Model `structuredContent` on `CallToolResult` (runtime passthrough already existed)
- Expand content `Annotations` with audience/priority/lastModified fields
- Document tool metadata registration in runtime surface docs

## Test plan
- [x] `pytest tests/unit/test_tool_metadata.py`
- [x] Full suite: 154 tests passed
- [ ] Verify `tools/list` in Cursor shows title/annotations/icons for a decorated tool
- [ ] Verify `tools/call` returns `structuredContent` when a tool returns it

Made with [Cursor](https://cursor.com)