### PR TITLE
Validate and propagate JSON-RPC _meta across the runtime

### DIFF
--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -80,6 +80,12 @@ to the client via the `request_sampling()` helper.
 
 - `notifications/message` (server -> client log notification via `send_log_message()`)
 
+## Request and Result Metadata (`_meta`)
+
+JSON-RPC requests may carry `_meta` at the top level or under `params`. The runtime validates that each present `_meta` value is an object and merges top-level and params metadata for handlers that need progress tokens or related-task links.
+
+Tool handlers lift `_meta` from a tool result body onto the JSON-RPC response envelope so clients receive metadata alongside the MCP result object. Task result responses use the same envelope-level `_meta` pattern.
+
 ## Capability Settings
 
 `CapabilitySettings` controls which fragments appear in `initialize.result.capabilities` and which optional runtime behaviors are enabled.

--- a/pymcp/protocol/meta.py
+++ b/pymcp/protocol/meta.py
@@ -1,0 +1,75 @@
+"""Helpers for JSON-RPC ``_meta`` validation and propagation."""
+
+from __future__ import annotations
+
+from .errors import MCPErrorCode
+from .json_types import JSONValue, JSONObject
+
+
+class MetaValidationError(ValueError):
+    """Raised when request metadata is malformed."""
+
+    code = MCPErrorCode.INVALID_PARAMS
+
+
+def validate_meta_value(value: JSONValue | None, *, location: str) -> JSONObject:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise MetaValidationError(f"{location} must be an object")
+    return dict(value)
+
+
+def validate_request_meta(data: JSONObject) -> None:
+    if "_meta" in data:
+        validate_meta_value(data.get("_meta"), location="_meta")
+    params = data.get("params")
+    if isinstance(params, dict) and "_meta" in params:
+        validate_meta_value(params.get("_meta"), location="params._meta")
+
+
+def extract_request_meta(data: JSONObject) -> JSONObject:
+    merged: JSONObject = {}
+    top_level = data.get("_meta")
+    if isinstance(top_level, dict):
+        merged.update(top_level)
+    params = data.get("params")
+    if isinstance(params, dict):
+        params_meta = params.get("_meta")
+        if isinstance(params_meta, dict):
+            merged.update(params_meta)
+    return merged
+
+
+def attach_meta(payload: JSONObject, meta: JSONObject | None) -> JSONObject:
+    if not meta:
+        return payload
+    merged = dict(payload)
+    existing = merged.get("_meta")
+    if isinstance(existing, dict):
+        combined = dict(existing)
+        combined.update(meta)
+        merged["_meta"] = combined
+    else:
+        merged["_meta"] = dict(meta)
+    return merged
+
+
+def split_result_meta(result: JSONObject) -> tuple[JSONObject, JSONObject | None]:
+    if "_meta" not in result:
+        return result, None
+    payload = dict(result)
+    meta_value = payload.pop("_meta")
+    if isinstance(meta_value, dict):
+        return payload, meta_value
+    return result, None
+
+
+__all__ = [
+    "MetaValidationError",
+    "attach_meta",
+    "extract_request_meta",
+    "split_result_meta",
+    "validate_meta_value",
+    "validate_request_meta",
+]

--- a/pymcp/protocol/meta.py
+++ b/pymcp/protocol/meta.py
@@ -62,7 +62,7 @@ def split_result_meta(result: JSONObject) -> tuple[JSONObject, JSONObject | None
     meta_value = payload.pop("_meta")
     if isinstance(meta_value, dict):
         return payload, meta_value
-    return result, None
+    return payload, None
 
 
 __all__ = [

--- a/pymcp/protocol/payload.py
+++ b/pymcp/protocol/payload.py
@@ -16,6 +16,7 @@ from ..settings import SUPPORTED_PROTOCOL_VERSIONS as SERVER_SUPPORTED_PROTOCOL_
 from .errors import MCPErrorCode
 from .json_types import JSONValue, JSONObject, RPCId
 from .jsonrpc import build_error_envelope, build_result_envelope
+from .meta import attach_meta
 
 
 SUPPORTED_PROTOCOL_VERSIONS: Final[tuple[str, ...]] = SERVER_SUPPORTED_PROTOCOL_VERSIONS
@@ -30,9 +31,7 @@ def error(rpc_id: RPCId, code: int, message: str, *, data: JSONValue | None = No
 
 
 def with_meta(payload: JSONObject, meta: JSONObject) -> JSONObject:
-    merged = dict(payload)
-    merged["_meta"] = meta
-    return merged
+    return attach_meta(payload, meta)
 
 
 def negotiate_protocol_version(

--- a/pymcp/runtime/dispatch.py
+++ b/pymcp/runtime/dispatch.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 
 from ..observability.logging import get_logger
 from ..protocol.errors import MCPErrorCode, build_error_response
+from ..protocol.meta import MetaValidationError, validate_request_meta
 from ..protocol.validate import validate_jsonrpc_request
 from ..registries.registry import get_registry_manager
 from ..security.authz import AuthorizationError, build_authz_request
@@ -243,6 +244,15 @@ class Dispatcher:
         session_manager, session = self._get_session(session_id=session_id, data=data, app=app)
         rpc_id, method = self._validate_envelope(data)
         self._validate_request(data)
+        try:
+            validate_request_meta(data)
+        except MetaValidationError as exc:
+            raise DispatchError(
+                status=200,
+                code=exc.code,
+                message=str(exc),
+                rpc_id=rpc_id if "id" in data else None,
+            ) from exc
 
         server_settings = getattr(app.state, "server_settings", None)
         if server_settings is None:

--- a/pymcp/runtime/handlers/lifecycle.py
+++ b/pymcp/runtime/handlers/lifecycle.py
@@ -125,8 +125,8 @@ async def handle_elicitation_create(ctx: DispatchContext) -> DispatchResult:
         return make_result(200, json_response=True, payload=payload)
 
     task_id = None
-    meta = ctx.data.get("_meta") or ctx.data.get("meta") or {}
-    if isinstance(meta, dict):
+    meta = ctx.request_meta
+    if meta:
         related = meta.get("io.modelcontextprotocol/related-task")
         if isinstance(related, dict):
             task_id_value = related.get("taskId")

--- a/pymcp/runtime/tools/handlers.py
+++ b/pymcp/runtime/tools/handlers.py
@@ -10,6 +10,7 @@ import anyio
 from ...observability.logging import get_logger
 from ...protocol.errors import MCPErrorCode
 from ...protocol.json_types import JSONObject
+from ...protocol.meta import split_result_meta
 from ...tasks.cancellation import CancellationToken, CancelledError
 from ..context import AppContext, RequestContext, SessionContext
 from ..handlers.registry import rpc_method
@@ -41,9 +42,9 @@ async def _handle_tools_call_task_augmented(
     if ttl_value is not None:
         ttl = int(ttl_value)
 
-    meta = ctx.data.get("_meta") or ctx.data.get("meta") or {}
+    meta = ctx.request_meta
     progress_token = None
-    if isinstance(meta, dict):
+    if meta:
         token = meta.get("progressToken")
         if isinstance(token, str) and token:
             progress_token = token
@@ -244,10 +245,9 @@ async def handle_tools_call(ctx: DispatchContext) -> DispatchResult:
             ctx.cancellation_manager.clear(token)
             return make_result(204, json_response=False, payload=None)
 
-        payload = ctx.payloads().success(
-            ctx.rpc_id,
-            normalize_tool_result(result),
-        )
+        normalized = normalize_tool_result(result)
+        result_body, result_meta = split_result_meta(normalized)
+        payload = ctx.success_payload(result_body, meta=result_meta)
 
         await ctx.maybe_enqueue(payload)
         ctx.cancellation_manager.clear(token)

--- a/pymcp/runtime/types.py
+++ b/pymcp/runtime/types.py
@@ -9,6 +9,9 @@ from typing import Any
 
 from fastapi import FastAPI
 
+from ..protocol.json_types import JSONValue
+from ..protocol.meta import attach_meta, extract_request_meta
+
 from ..capabilities import build_capabilities
 from ..protocol.payload import PayloadFactory, get_payload_factory
 from ..registries.registry import RegistryManager
@@ -92,6 +95,35 @@ class DispatchContext:
     def payloads(self, *, protocol_version: str | None = None) -> PayloadFactory:
         version = protocol_version or self.session.protocol_version
         return get_payload_factory(version, app=self.app)
+
+    @property
+    def request_meta(self) -> JSONObject:
+        return extract_request_meta(self.data)
+
+    def success_payload(
+        self,
+        result: JSONObject,
+        *,
+        meta: JSONObject | None = None,
+    ) -> JSONObject:
+        payload = self.payloads().success(self.rpc_id, result)
+        combined = dict(meta or {})
+        if combined:
+            return attach_meta(payload, combined)
+        return payload
+
+    def error_payload(
+        self,
+        code: int,
+        message: str,
+        *,
+        meta: JSONObject | None = None,
+        data: JSONValue | None = None,
+    ) -> JSONObject:
+        payload = self.payloads().error(self.rpc_id, code, message, data=data)
+        if meta:
+            return attach_meta(payload, meta)
+        return payload
 
     async def maybe_enqueue(
         self,

--- a/tests/unit/test_meta_support.py
+++ b/tests/unit/test_meta_support.py
@@ -1,0 +1,150 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from pymcp import create_app
+from pymcp.protocol.meta import (
+    MetaValidationError,
+    attach_meta,
+    extract_request_meta,
+    split_result_meta,
+    validate_meta_value,
+    validate_request_meta,
+)
+from pymcp.protocol.errors import MCPErrorCode
+from pymcp.registry import tool_registry
+
+
+def _headers(session_id=None, *, accept="application/json, text/event-stream"):
+    headers = {"Accept": accept}
+    if session_id:
+        headers["MCP-Session-Id"] = session_id
+    return headers
+
+
+def _initialize_session(client: TestClient):
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "clientInfo": {"name": "test-client", "version": "1.0.0"},
+        },
+    }
+    response = client.post("/mcp", json=payload, headers=_headers())
+    assert response.status_code == 200
+    return response.headers["MCP-Session-Id"]
+
+
+def test_validate_meta_value_rejects_non_object():
+    with pytest.raises(MetaValidationError, match="must be an object"):
+        validate_meta_value("bad", location="_meta")
+
+
+def test_validate_request_meta_accepts_top_level_and_params():
+    validate_request_meta(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "_meta": {"progressToken": "pt-1"},
+            "params": {"name": "demo", "_meta": {"client": "test"}},
+        }
+    )
+
+
+def test_validate_request_meta_rejects_invalid_params_meta():
+    with pytest.raises(MetaValidationError, match="params._meta"):
+        validate_request_meta(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "demo", "_meta": []},
+            }
+        )
+
+
+def test_extract_request_meta_merges_top_level_and_params():
+    merged = extract_request_meta(
+        {
+            "_meta": {"progressToken": "pt-1"},
+            "params": {"_meta": {"client": "test"}},
+        }
+    )
+    assert merged == {"progressToken": "pt-1", "client": "test"}
+
+
+def test_attach_meta_merges_existing_envelope_meta():
+    payload = attach_meta({"jsonrpc": "2.0", "id": 1, "result": {}}, {"a": 1})
+    payload = attach_meta(payload, {"b": 2})
+    assert payload["_meta"] == {"a": 1, "b": 2}
+
+
+def test_split_result_meta_lifts_meta_from_result_body():
+    body, meta = split_result_meta(
+        {
+            "content": [{"type": "text", "text": "ok"}],
+            "_meta": {"progressToken": "pt-2"},
+        }
+    )
+    assert "_meta" not in body
+    assert meta == {"progressToken": "pt-2"}
+
+
+def test_dispatch_rejects_invalid_request_meta():
+    client = TestClient(create_app())
+    session_id = _initialize_session(client)
+    client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers=_headers(session_id),
+    )
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "_meta": "not-an-object",
+        },
+        headers=_headers(session_id),
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["error"]["code"] == MCPErrorCode.INVALID_PARAMS
+    assert "_meta must be an object" in body["error"]["message"]
+
+
+def test_tools_call_lifts_result_meta_to_response_envelope():
+    @tool_registry.register
+    def meta_tool() -> dict[str, object]:
+        return {
+            "content": [{"type": "text", "text": "done"}],
+            "_meta": {"progressToken": "pt-tool"},
+        }
+
+    client = TestClient(create_app())
+    session_id = _initialize_session(client)
+    client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers=_headers(session_id),
+    )
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "meta_tool", "arguments": {}},
+        },
+        headers=_headers(session_id),
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["result"]["content"][0]["text"] == "done"
+    assert "_meta" not in body["result"]
+    assert body["_meta"] == {"progressToken": "pt-tool"}

--- a/tests/unit/test_meta_support.py
+++ b/tests/unit/test_meta_support.py
@@ -54,7 +54,7 @@ def test_validate_request_meta_accepts_top_level_and_params():
 
 
 def test_validate_request_meta_rejects_invalid_params_meta():
-    with pytest.raises(MetaValidationError, match="params._meta"):
+    with pytest.raises(MetaValidationError, match=r"params\._meta"):
         validate_request_meta(
             {
                 "jsonrpc": "2.0",
@@ -90,6 +90,12 @@ def test_split_result_meta_lifts_meta_from_result_body():
     )
     assert "_meta" not in body
     assert meta == {"progressToken": "pt-2"}
+
+
+def test_split_result_meta_strips_invalid_meta():
+    body, meta = split_result_meta({"content": [], "_meta": "invalid"})
+    assert body == {"content": []}
+    assert meta is None
 
 
 def test_dispatch_rejects_invalid_request_meta():


### PR DESCRIPTION
## Summary
- Add shared `_meta` helpers for validation, request extraction, envelope attachment, and result splitting.
- Reject malformed request `_meta` at dispatch with `INVALID_PARAMS`, and wire handlers to use merged request metadata consistently.
- Lift `_meta` from tool result bodies onto the JSON-RPC response envelope; add unit/integration tests and runtime-surface docs.

## Test plan
- [x] `uv run pytest tests/unit/test_meta_support.py`
- [x] `uv run pytest` (159 passed)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for metadata (`_meta`) in JSON-RPC requests and responses.
  * Metadata can be specified at the top level or within request parameters.
  * Metadata from multiple sources is automatically merged.
  * Tool results can include metadata that is propagated to the response envelope.

* **Tests**
  * Added comprehensive test coverage for metadata validation and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->