### PR TITLE
Implement completion/complete for prompts and resource templates

### DIFF
--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -82,6 +82,31 @@ via the `request_roots_list()` helper (sends `roots/list` to the client).
 
 - `completion/complete`
 
+Prompt argument completions are resolved from each argument's `schema.enum` or
+explicit `completion` list. Resource template variable completions are resolved
+from optional `variables` metadata passed to `register_template()`.
+
+```python
+@prompt_registry.register(
+    arguments=[
+        {
+            "name": "language",
+            "required": True,
+            "schema": {"type": "string", "enum": ["python", "javascript", "rust"]},
+        }
+    ]
+)
+def languagePrompt(language: str) -> str:
+    return language
+
+@resource_registry.register_template(
+    uri_template="memo://{topic}",
+    variables={"topic": {"completion": ["welcome", "release-notes"]}},
+)
+def memoTemplate(topic: str) -> str:
+    return topic
+```
+
 ### Tasks
 
 - `tasks/list`

--- a/pymcp/protocol/types.py
+++ b/pymcp/protocol/types.py
@@ -376,9 +376,17 @@ class CompletionArgument(BaseModel):
     value: str = Field(..., description="Partial argument value to complete")
 
 
+class CompletionContext(BaseModel):
+    arguments: JSONObject = Field(default_factory=dict, description="Already-resolved argument values")
+
+
 class CompleteRequestParams(BaseModel):
     ref: CompletionRef = Field(..., description="Reference to complete against")
     argument: CompletionArgument = Field(..., description="Argument to complete")
+    context: CompletionContext | None = Field(
+        default=None,
+        description="Optional context from previously resolved arguments",
+    )
 
 
 class Completion(BaseModel):
@@ -468,6 +476,7 @@ __all__ = [
     "CallToolResult",
     "CancelledNotification",
     "CancelledNotificationParams",
+    "CompletionContext",
     "CompleteRequestParams",
     "CompleteResult",
     "Completion",

--- a/pymcp/registries/registry.py
+++ b/pymcp/registries/registry.py
@@ -226,6 +226,7 @@ class ResourceTemplateDefinition:
     description: str
     mime_type: str
     function: SyncOrAsyncCallable
+    variables: dict[str, dict[str, Any]] | None = None
     _matcher: re.Pattern[str] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -545,6 +546,7 @@ class ResourceRegistry(_RegistryBase):
         name: str | None = None,
         description: str | None = None,
         mime_type: str = "text/plain",
+        variables: dict[str, dict[str, Any]] | None = None,
     ) -> Callable[[SyncOrAsyncCallable], SyncOrAsyncCallable] | SyncOrAsyncCallable:
         if func is None:
             return lambda callback: self.register_template(
@@ -553,6 +555,7 @@ class ResourceRegistry(_RegistryBase):
                 name=name,
                 description=description,
                 mime_type=mime_type,
+                variables=variables,
             )
 
         manager = get_current_registry_manager()
@@ -563,6 +566,7 @@ class ResourceRegistry(_RegistryBase):
                 name=name,
                 description=description,
                 mime_type=mime_type,
+                variables=variables,
             )
 
         template_name = name or func.__name__
@@ -573,6 +577,7 @@ class ResourceRegistry(_RegistryBase):
             description=template_description,
             mime_type=mime_type,
             function=func,
+            variables=variables,
         )
         signature = inspect.signature(func)
         available = set(definition._matcher.groupindex)

--- a/pymcp/runtime/handlers/completion_support.py
+++ b/pymcp/runtime/handlers/completion_support.py
@@ -1,0 +1,101 @@
+"""Completion resolution helpers for prompts and resource templates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...protocol.errors import MCPErrorCode
+from ...registries.registry import PromptDefinition, RegistryManager
+from ...util.completion import (
+    build_completion_result,
+    completion_candidates_from_argument,
+    extract_template_variables,
+)
+
+
+class CompletionResolutionError(Exception):
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _template_variable_completions(template: Any, variable: str) -> list[str]:
+    variables = getattr(template, "variable_completions", None)
+    if isinstance(variables, dict):
+        values = variables.get(variable)
+        if isinstance(values, list):
+            return [str(value) for value in values]
+
+    metadata = getattr(template, "variables", None)
+    if isinstance(metadata, dict):
+        variable_meta = metadata.get(variable)
+        if isinstance(variable_meta, dict):
+            return completion_candidates_from_argument(variable_meta)
+
+    return []
+
+
+def resolve_prompt_completion(
+    *,
+    registry_manager: RegistryManager,
+    prompt_name: str,
+    argument_name: str,
+    argument_value: str,
+) -> dict[str, object]:
+    prompt = registry_manager.get_prompt_registry().get(prompt_name)
+    if prompt is None:
+        raise CompletionResolutionError(MCPErrorCode.INVALID_PARAMS, f"Unknown prompt: {prompt_name}")
+
+    candidates = _prompt_completion_candidates(prompt, argument_name)
+    if not candidates:
+        return build_completion_result([], prefix=argument_value)
+    return build_completion_result(candidates, prefix=argument_value)
+
+
+def resolve_resource_completion(
+    *,
+    registry_manager: RegistryManager,
+    uri_template: str,
+    argument_name: str,
+    argument_value: str,
+) -> dict[str, object]:
+    resource_registry = registry_manager.get_resource_registry()
+    get_template = getattr(resource_registry, "get_template", None)
+    if not callable(get_template):
+        raise CompletionResolutionError(
+            MCPErrorCode.METHOD_NOT_FOUND,
+            "Resource template completions are not supported",
+        )
+
+    template = get_template(uri_template)
+    if template is None:
+        raise CompletionResolutionError(
+            MCPErrorCode.RESOURCE_NOT_FOUND,
+            f"Unknown resource template: {uri_template}",
+        )
+
+    variables = extract_template_variables(uri_template)
+    if argument_name not in variables:
+        raise CompletionResolutionError(
+            MCPErrorCode.INVALID_PARAMS,
+            f"Unknown template argument: {argument_name}",
+        )
+
+    candidates = _template_variable_completions(template, argument_name)
+    return build_completion_result(candidates, prefix=argument_value)
+
+
+def _prompt_completion_candidates(prompt: PromptDefinition, argument_name: str) -> list[str]:
+    for argument in prompt.arguments:
+        if argument.get("name") != argument_name:
+            continue
+        return completion_candidates_from_argument(argument)
+    return []
+
+
+__all__ = [
+    "CompletionResolutionError",
+    "resolve_prompt_completion",
+    "resolve_resource_completion",
+]

--- a/pymcp/runtime/handlers/completion_support.py
+++ b/pymcp/runtime/handlers/completion_support.py
@@ -21,18 +21,11 @@ class CompletionResolutionError(Exception):
 
 
 def _template_variable_completions(template: Any, variable: str) -> list[str]:
-    variables = getattr(template, "variable_completions", None)
+    variables = getattr(template, "variables", None)
     if isinstance(variables, dict):
-        values = variables.get(variable)
-        if isinstance(values, list):
-            return [str(value) for value in values]
-
-    metadata = getattr(template, "variables", None)
-    if isinstance(metadata, dict):
-        variable_meta = metadata.get(variable)
+        variable_meta = variables.get(variable)
         if isinstance(variable_meta, dict):
             return completion_candidates_from_argument(variable_meta)
-
     return []
 
 

--- a/pymcp/runtime/handlers/completions.py
+++ b/pymcp/runtime/handlers/completions.py
@@ -1,7 +1,7 @@
 """Completion handler for argument autocompletion.
 
 Implements ``completion/complete`` which provides completion suggestions
-for prompt or resource arguments.
+for prompt or resource template arguments.
 """
 
 from __future__ import annotations
@@ -9,6 +9,7 @@ from __future__ import annotations
 from ...observability.logging import get_logger
 from ...protocol.errors import MCPErrorCode
 from ..types import DispatchContext, DispatchResult, make_result
+from .completion_support import CompletionResolutionError, resolve_prompt_completion, resolve_resource_completion
 from .registry import rpc_method
 
 logger = get_logger(__name__)
@@ -42,30 +43,63 @@ async def handle_completion_complete(ctx: DispatchContext) -> DispatchResult:
     ref_type = ref.get("type", "")
     arg_name = argument.get("name", "")
     arg_value = argument.get("value", "")
+    if not isinstance(arg_name, str) or not arg_name:
+        payload = ctx.payloads().error(
+            ctx.rpc_id,
+            MCPErrorCode.INVALID_PARAMS,
+            "Missing or invalid argument name",
+        )
+        await ctx.maybe_enqueue(payload)
+        return make_result(200, json_response=True, payload=payload)
+    if not isinstance(arg_value, str):
+        arg_value = "" if arg_value is None else str(arg_value)
 
-    values: list[str] = []
+    context = params.get("context")
+    if context is not None and not isinstance(context, dict):
+        payload = ctx.payloads().error(
+            ctx.rpc_id,
+            MCPErrorCode.INVALID_PARAMS,
+            "Invalid completion context",
+        )
+        await ctx.maybe_enqueue(payload)
+        return make_result(200, json_response=True, payload=payload)
+    _ = context
 
-    if ref_type == "ref/prompt":
-        prompt_name = ref.get("name", "")
-        prompt_def = ctx.registry_manager.prompt_registry.get(prompt_name)
-        if prompt_def is not None:
-            for prompt_arg in prompt_def.arguments:
-                if prompt_arg.get("name") == arg_name:
-                    # Prompts don't carry enum values, so return empty
-                    break
-    elif ref_type == "ref/resource":
-        pass  # Resource completions are not commonly used
+    try:
+        if ref_type == "ref/prompt":
+            prompt_name = ref.get("name", "")
+            if not isinstance(prompt_name, str) or not prompt_name:
+                raise CompletionResolutionError(MCPErrorCode.INVALID_PARAMS, "Missing prompt name")
+            completion = resolve_prompt_completion(
+                registry_manager=ctx.registry_manager,
+                prompt_name=prompt_name,
+                argument_name=arg_name,
+                argument_value=arg_value,
+            )
+        elif ref_type == "ref/resource":
+            uri_template = ref.get("uri", "")
+            if not isinstance(uri_template, str) or not uri_template:
+                raise CompletionResolutionError(MCPErrorCode.INVALID_PARAMS, "Missing resource URI template")
+            completion = resolve_resource_completion(
+                registry_manager=ctx.registry_manager,
+                uri_template=uri_template,
+                argument_name=arg_name,
+                argument_value=arg_value,
+            )
+        else:
+            payload = ctx.payloads().error(
+                ctx.rpc_id,
+                MCPErrorCode.INVALID_PARAMS,
+                f"Unsupported completion ref type: {ref_type}",
+            )
+            await ctx.maybe_enqueue(payload)
+            return make_result(200, json_response=True, payload=payload)
+    except CompletionResolutionError as exc:
+        payload = ctx.payloads().error(ctx.rpc_id, exc.code, exc.message)
+        await ctx.maybe_enqueue(payload)
+        return make_result(200, json_response=True, payload=payload)
 
-    payload = ctx.payloads().success(
-        ctx.rpc_id,
-        {
-            "completion": {
-                "values": values,
-                "hasMore": False,
-            }
-        },
-    )
-    _ = arg_value  # reserved for future filtering
+    payload = ctx.payloads().success(ctx.rpc_id, {"completion": completion})
     await ctx.maybe_enqueue(payload)
     return make_result(200, json_response=True, payload=payload)
 

--- a/pymcp/util/completion.py
+++ b/pymcp/util/completion.py
@@ -32,14 +32,13 @@ def rank_completions(candidates: list[str], prefix: str) -> list[str]:
 
     normalized_prefix = prefix.casefold()
     if not normalized_prefix:
-        return sorted(candidates, key=str.casefold)
+        return list(candidates)
 
     prefix_matches = [value for value in candidates if value.casefold().startswith(normalized_prefix)]
     if prefix_matches:
-        return sorted(prefix_matches, key=lambda value: (len(value), value.casefold()))
+        return prefix_matches
 
-    substring_matches = [value for value in candidates if normalized_prefix in value.casefold()]
-    return sorted(substring_matches, key=lambda value: (len(value), value.casefold()))
+    return [value for value in candidates if normalized_prefix in value.casefold()]
 
 
 def paginate_completions(

--- a/pymcp/util/completion.py
+++ b/pymcp/util/completion.py
@@ -1,0 +1,71 @@
+"""Helpers for MCP completion/complete suggestion ranking and pagination."""
+
+from __future__ import annotations
+
+import re
+
+_COMPLETION_PAGE_SIZE = 100
+_TEMPLATE_VARIABLE_PATTERN = re.compile(r"\{([^}]+)\}")
+
+
+def extract_template_variables(uri_template: str) -> list[str]:
+    return _TEMPLATE_VARIABLE_PATTERN.findall(uri_template)
+
+
+def completion_candidates_from_argument(argument: dict[str, object]) -> list[str]:
+    completion = argument.get("completion")
+    if isinstance(completion, list):
+        return [str(value) for value in completion]
+
+    schema = argument.get("schema")
+    if isinstance(schema, dict):
+        enum = schema.get("enum")
+        if isinstance(enum, list):
+            return [str(value) for value in enum]
+
+    return []
+
+
+def rank_completions(candidates: list[str], prefix: str) -> list[str]:
+    if not candidates:
+        return []
+
+    normalized_prefix = prefix.casefold()
+    if not normalized_prefix:
+        return sorted(candidates, key=str.casefold)
+
+    prefix_matches = [value for value in candidates if value.casefold().startswith(normalized_prefix)]
+    if prefix_matches:
+        return sorted(prefix_matches, key=lambda value: (len(value), value.casefold()))
+
+    substring_matches = [value for value in candidates if normalized_prefix in value.casefold()]
+    return sorted(substring_matches, key=lambda value: (len(value), value.casefold()))
+
+
+def paginate_completions(
+    values: list[str],
+    *,
+    limit: int = _COMPLETION_PAGE_SIZE,
+) -> tuple[list[str], int, bool]:
+    total = len(values)
+    page = values[:limit]
+    return page, total, total > limit
+
+
+def build_completion_result(values: list[str], *, prefix: str) -> dict[str, object]:
+    ranked = rank_completions(values, prefix)
+    page, total, has_more = paginate_completions(ranked)
+    return {
+        "values": page,
+        "total": total,
+        "hasMore": has_more,
+    }
+
+
+__all__ = [
+    "build_completion_result",
+    "completion_candidates_from_argument",
+    "extract_template_variables",
+    "paginate_completions",
+    "rank_completions",
+]

--- a/tests/unit/test_completion_util.py
+++ b/tests/unit/test_completion_util.py
@@ -1,0 +1,22 @@
+from pymcp.util.completion import (
+    build_completion_result,
+    extract_template_variables,
+    rank_completions,
+)
+
+
+def test_extract_template_variables():
+    assert extract_template_variables("memo://{topic}/{section}") == ["topic", "section"]
+
+
+def test_rank_completions_prefix_and_substring():
+    values = rank_completions(["python", "pytorch", "pyside", "java"], "py")
+    assert values == ["python", "pytorch", "pyside"]
+
+
+def test_build_completion_result_paginates():
+    candidates = [f"item-{index}" for index in range(105)]
+    result = build_completion_result(candidates, prefix="")
+    assert len(result["values"]) == 100
+    assert result["total"] == 105
+    assert result["hasMore"] is True

--- a/tests/unit/test_completions_handler.py
+++ b/tests/unit/test_completions_handler.py
@@ -3,6 +3,7 @@
 import pytest
 
 from pymcp import create_app
+from pymcp.registry import prompt_registry, resource_registry
 from pymcp.runtime.dispatch import process_jsonrpc_message
 from pymcp.session.store import get_session_manager
 from pymcp.settings import CapabilitySettings, ServerSettings
@@ -19,6 +20,20 @@ async def _ready_session(app):
     return session
 
 
+async def _complete(app, session_id: str, params: dict, *, request_id: int = 1):
+    return await process_jsonrpc_message(
+        session_id,
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "completion/complete",
+            "params": params,
+        },
+        app=app,
+        direct_response=True,
+    )
+
+
 async def test_completions_gated_when_disabled():
     app = create_app(
         middleware_config=None,
@@ -28,26 +43,33 @@ async def test_completions_gated_when_disabled():
     )
     session = await _ready_session(app)
 
-    result = await process_jsonrpc_message(
+    result = await _complete(
+        app,
         session.session_id,
         {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "completion/complete",
-            "params": {
-                "ref": {"type": "ref/prompt", "name": "test"},
-                "argument": {"name": "topic", "value": "wea"},
-            },
+            "ref": {"type": "ref/prompt", "name": "test"},
+            "argument": {"name": "topic", "value": "wea"},
         },
-        app=app,
-        direct_response=True,
     )
     assert result.status == 200
     assert result.payload["error"]["code"] == -32601
     assert "completions not supported" in result.payload["error"]["message"]
 
 
-async def test_completions_returns_empty_when_enabled():
+async def test_prompt_completion_uses_enum_values():
+    @prompt_registry.register(
+        name="languagePrompt",
+        arguments=[
+            {
+                "name": "language",
+                "required": True,
+                "schema": {"type": "string", "enum": ["python", "pytorch", "pyside", "java"]},
+            }
+        ],
+    )
+    def languagePrompt(language: str) -> str:
+        return language
+
     app = create_app(
         middleware_config=None,
         server_settings=ServerSettings(
@@ -56,23 +78,73 @@ async def test_completions_returns_empty_when_enabled():
     )
     session = await _ready_session(app)
 
-    result = await process_jsonrpc_message(
+    result = await _complete(
+        app,
         session.session_id,
         {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "completion/complete",
-            "params": {
-                "ref": {"type": "ref/prompt", "name": "test"},
-                "argument": {"name": "topic", "value": "wea"},
-            },
+            "ref": {"type": "ref/prompt", "name": "languagePrompt"},
+            "argument": {"name": "language", "value": "py"},
         },
-        app=app,
-        direct_response=True,
     )
-    assert result.status == 200
     completion = result.payload["result"]["completion"]
-    assert isinstance(completion["values"], list)
+    assert completion["values"] == ["python", "pytorch", "pyside"]
+    assert completion["total"] == 3
+    assert completion["hasMore"] is False
+
+
+async def test_prompt_completion_rejects_unknown_prompt():
+    app = create_app(
+        middleware_config=None,
+        server_settings=ServerSettings(
+            capabilities=CapabilitySettings(completions_enabled=True)
+        ),
+    )
+    session = await _ready_session(app)
+
+    result = await _complete(
+        app,
+        session.session_id,
+        {
+            "ref": {"type": "ref/prompt", "name": "missingPrompt"},
+            "argument": {"name": "topic", "value": "wea"},
+        },
+    )
+    assert result.payload["error"]["code"] == -32602
+    assert "Unknown prompt" in result.payload["error"]["message"]
+
+
+async def test_resource_template_completion_uses_variable_metadata():
+    @resource_registry.register_template(
+        uri_template="memo://{topic}",
+        name="memo_template",
+        variables={
+            "topic": {
+                "completion": ["welcome", "release-notes", "security"],
+            }
+        },
+    )
+    def memoTemplate(topic: str) -> str:
+        return topic
+
+    app = create_app(
+        middleware_config=None,
+        server_settings=ServerSettings(
+            capabilities=CapabilitySettings(completions_enabled=True)
+        ),
+    )
+    session = await _ready_session(app)
+
+    result = await _complete(
+        app,
+        session.session_id,
+        {
+            "ref": {"type": "ref/resource", "uri": "memo://{topic}"},
+            "argument": {"name": "topic", "value": "re"},
+        },
+    )
+    completion = result.payload["result"]["completion"]
+    assert completion["values"] == ["release-notes"]
+    assert completion["total"] == 1
     assert completion["hasMore"] is False
 
 
@@ -85,16 +157,10 @@ async def test_completions_rejects_missing_ref():
     )
     session = await _ready_session(app)
 
-    result = await process_jsonrpc_message(
+    result = await _complete(
+        app,
         session.session_id,
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "completion/complete",
-            "params": {"argument": {"name": "topic", "value": "wea"}},
-        },
-        app=app,
-        direct_response=True,
+        {"argument": {"name": "topic", "value": "wea"}},
     )
     assert result.payload["error"]["code"] == -32602
 
@@ -108,15 +174,9 @@ async def test_completions_rejects_missing_argument():
     )
     session = await _ready_session(app)
 
-    result = await process_jsonrpc_message(
+    result = await _complete(
+        app,
         session.session_id,
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "completion/complete",
-            "params": {"ref": {"type": "ref/prompt", "name": "test"}},
-        },
-        app=app,
-        direct_response=True,
+        {"ref": {"type": "ref/prompt", "name": "test"}},
     )
     assert result.payload["error"]["code"] == -32602


### PR DESCRIPTION
Replaces #20, which GitHub auto-closed when its stacked base branch was deleted after #17 merged. Rebuilt by replaying the original completion commits onto current master.\n\nCloses #20.