### PR TITLE
Run official MCP conformance tests in CI

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,34 @@
+name: MCP Conformance
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install server
+        run: python -m pip install -e .
+      - name: Start conformance server
+        run: |
+          uvicorn tests.conformance_server:app --host 127.0.0.1 --port 3001 > /tmp/pymcp-conformance.log 2>&1 &
+          echo $! > /tmp/pymcp-conformance.pid
+          timeout 15 bash -c 'until curl -s -o /dev/null http://127.0.0.1:3001/mcp; do sleep 0.5; done'
+      - name: Run official MCP server conformance suite
+        uses: modelcontextprotocol/conformance@v0.1.11
+        with:
+          mode: server
+          url: http://127.0.0.1:3001/mcp
+          suite: active
+          expected-failures: ./conformance-baseline.yml
+          verbose: true
+      - name: Show server logs on failure
+        if: failure()
+        run: cat /tmp/pymcp-conformance.log

--- a/conformance-baseline.yml
+++ b/conformance-baseline.yml
@@ -1,0 +1,26 @@
+# Temporary known failures in the official MCP conformance suite.
+# The runner fails when an entry becomes stale, so fixed scenarios must be removed.
+server:
+  - completion-complete
+  - tools-call-simple-text
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-logging
+  - tools-call-error
+  - tools-call-with-progress
+  - tools-call-sampling
+  - tools-call-elicitation
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - resources-subscribe
+  - resources-unsubscribe
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  - dns-rebinding-protection

--- a/pymcp/transport/streamable_http.py
+++ b/pymcp/transport/streamable_http.py
@@ -311,8 +311,15 @@ async def mcp_post(request: Request) -> Response:
     rejected = _reject_invalid_origin(request) or _reject_invalid_protocol_version(request)
     if rejected:
         return rejected
-    if not accept_contains(request, "application/json"):
-        return _jsonrpc_http_error(406, INVALID_PARAMS, "Accept header must include application/json")
+    if not (
+        accept_contains(request, "application/json")
+        and accept_contains(request, "text/event-stream")
+    ):
+        return _jsonrpc_http_error(
+            406,
+            INVALID_PARAMS,
+            "Accept header must include application/json and text/event-stream",
+        )
 
     body = await try_parse_json_body(request)
     if body is None:

--- a/tests/conformance_server.py
+++ b/tests/conformance_server.py
@@ -1,0 +1,71 @@
+"""MCP server fixture exercised by the official conformance test suite."""
+
+from __future__ import annotations
+
+from pymcp import (
+    CapabilitySettings,
+    ServerSettings,
+    create_app,
+    prompt_registry,
+    resource_registry,
+    tool_registry,
+)
+
+
+@tool_registry.register(
+    name="echo",
+    title="Echo",
+    output_schema={
+        "type": "object",
+        "properties": {"value": {"type": "string"}},
+        "required": ["value"],
+    },
+)
+def echo(value: str) -> dict:
+    """Return the supplied string."""
+
+    return {
+        "content": [{"type": "text", "text": value}],
+        "structuredContent": {"value": value},
+    }
+
+
+@prompt_registry.register(name="greeting", description="Generate a greeting.")
+def greeting(name: str) -> str:
+    return f"Hello, {name}!"
+
+
+@resource_registry.register(
+    uri="test://static",
+    name="static_resource",
+    description="Static conformance resource.",
+)
+def static_resource() -> str:
+    return "conformance"
+
+
+@resource_registry.register_template(
+    uri_template="test://items/{item}",
+    name="item_resource",
+    description="Parameterized conformance resource.",
+)
+def item_resource(item: str) -> str:
+    return item
+
+
+app = create_app(
+    middleware_config=None,
+    server_settings=ServerSettings(
+        name="pymcp-kit-conformance",
+        version="0.1.0",
+        capabilities=CapabilitySettings(
+            prompts_list_changed=True,
+            resources_list_changed=True,
+            resources_subscribe=True,
+            tools_list_changed=True,
+            logging_enabled=True,
+            completions_enabled=True,
+            tasks_enabled=True,
+        ),
+    ),
+)

--- a/tests/unit/test_elicitation.py
+++ b/tests/unit/test_elicitation.py
@@ -54,7 +54,7 @@ async def test_streamable_http_response_only_resolves_pending_elicitation():
         "/mcp",
         json={"jsonrpc": "2.0", "id": "elic-1", "result": {"action": "accept"}},
         headers={
-            "Accept": "application/json",
+            "Accept": "application/json, text/event-stream",
             "MCP-Session-Id": session.session_id,
         },
     )

--- a/tests/unit/test_streamable_http_transport.py
+++ b/tests/unit/test_streamable_http_transport.py
@@ -146,3 +146,24 @@ def test_streamable_http_preserves_session_principal_and_rejects_mismatch():
     )
     assert mismatched.status_code == 403
     assert mismatched.json()["error"]["message"] == "Session principal mismatch"
+
+
+@pytest.mark.parametrize(
+    "accept",
+    [
+        "application/json",
+        "text/event-stream",
+        "application/json, text/event-stream;q=0",
+    ],
+)
+def test_streamable_http_post_requires_json_and_sse_accept_types(accept):
+    client = TestClient(create_app(middleware_config=None))
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        headers={"Accept": accept},
+    )
+    assert response.status_code == 406
+    assert response.json()["error"]["message"] == (
+        "Accept header must include application/json and text/event-stream"
+    )


### PR DESCRIPTION
## Summary
- require Streamable HTTP POST clients to advertise both JSON and SSE response media types
- add a deterministic MCP conformance server fixture
- run `modelcontextprotocol/conformance@v0.1.11` in GitHub Actions
- check in an exact expected-failures baseline that fails on regressions and stale entries

## Verification
- `197 passed`
- Ruff passes
- official active suite: 8 passing, 23 explicitly baselined

Part of #24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added automated conformance testing workflow to validate MCP protocol compliance on every push and pull request.
  * Added test server with sample tools, prompts, and resource endpoints for testing.

* **Bug Fixes**
  * HTTP POST endpoint now requires `Accept` header to include both `application/json` and `text/event-stream`; requests missing either will receive a 406 error.

* **Tests**
  * Added conformance test suite and updated tests to validate Accept header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->