### PR TITLE
Document MCP auth scope boundary

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -101,3 +101,9 @@ When authentication is enabled, task ownership follows the authenticated princip
 - keep JSON authz policies in a separate file
 - pass `authn`, `authz`, and `require_authn` into `create_app()`
 - use capability and tool filtering if clients should not even discover restricted functionality
+
+## Scope Boundary
+
+`pymcp-kit` provides HTTP authentication hooks, authorization hooks, and OAuth protected-resource metadata discovery for MCP resource servers.
+
+It does not implement a full authorization server, a full OAuth client, or token issuance flows. Those belong in your deployment architecture, not in this server toolkit.

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -108,6 +108,22 @@ def test_oauth_protected_resource_metadata_route():
     }
 
 
+def test_oauth_protected_resource_metadata_route_supports_mcp_suffix():
+    config = MiddlewareConfig(
+        oauth=OAuthProtectedResourceConfig(
+            authorization_servers=["https://auth.example.com"],
+            scopes_supported=["files:read"],
+        )
+    )
+    app = create_app(middleware_config=config)
+    client = TestClient(app)
+
+    response = client.get("/.well-known/oauth-protected-resource/mcp")
+
+    assert response.status_code == 200
+    assert response.json()["resource"] == "http://testserver/mcp"
+
+
 def test_create_app_kwargs_forward_oauth_config_to_middleware():
     app = create_app(
         middleware_config=None,


### PR DESCRIPTION
Covers the auth box from issue #24.

This PR keeps the existing discovery/challenge behavior covered by tests and documents the boundary between this toolkit and a full OAuth authorization server or client stack.

Validation:
- PYTHONPYCACHEPREFIX=/tmp/pycache /Users/proshan/py-mcp/.venv/bin/pytest tests/test_middleware.py -q