### PR TITLE
Add prompt and resource metadata support

### DIFF
--- a/pymcp/registries/registry.py
+++ b/pymcp/registries/registry.py
@@ -182,6 +182,8 @@ class PromptDefinition:
     description: str
     arguments: list[dict[str, Any]]
     function: SyncOrAsyncCallable
+    title: str | None = None
+    icons: list[dict[str, Any]] | None = None
 
     def to_mcp_payload(self) -> dict[str, Any]:
         payload = {
@@ -189,6 +191,10 @@ class PromptDefinition:
             "description": self.description,
             "arguments": [],
         }
+        if self.title:
+            payload["title"] = self.title
+        if self.icons:
+            payload["icons"] = [dict(icon) for icon in self.icons]
         args: list[dict[str, Any]] = []
         for argument in self.arguments:
             args.append(
@@ -209,14 +215,27 @@ class ResourceDefinition:
     description: str
     mime_type: str
     function: SyncOrAsyncCallable
+    title: str | None = None
+    icons: list[dict[str, Any]] | None = None
+    annotations: dict[str, Any] | None = None
+    size: int | None = None
 
     def to_mcp_payload(self) -> dict[str, Any]:
-        return {
+        payload = {
             "uri": self.uri,
             "name": self.name,
             "description": self.description,
             "mimeType": self.mime_type,
         }
+        if self.title:
+            payload["title"] = self.title
+        if self.icons:
+            payload["icons"] = [dict(icon) for icon in self.icons]
+        if self.annotations:
+            payload["annotations"] = dict(self.annotations)
+        if self.size is not None:
+            payload["size"] = self.size
+        return payload
 
 
 @dataclass(slots=True)
@@ -227,18 +246,28 @@ class ResourceTemplateDefinition:
     mime_type: str
     function: SyncOrAsyncCallable
     variables: dict[str, dict[str, Any]] | None = None
+    title: str | None = None
+    icons: list[dict[str, Any]] | None = None
+    annotations: dict[str, Any] | None = None
     _matcher: re.Pattern[str] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "_matcher", compile_uri_template(self.uri_template))
 
     def to_mcp_payload(self) -> dict[str, Any]:
-        return {
+        payload = {
             "uriTemplate": self.uri_template,
             "name": self.name,
             "description": self.description,
             "mimeType": self.mime_type,
         }
+        if self.title:
+            payload["title"] = self.title
+        if self.icons:
+            payload["icons"] = [dict(icon) for icon in self.icons]
+        if self.annotations:
+            payload["annotations"] = dict(self.annotations)
+        return payload
 
     def match(self, uri: str) -> dict[str, str] | None:
         match = self._matcher.match(uri)
@@ -430,6 +459,8 @@ class PromptRegistry(_RegistryBase):
         name: str | None = None,
         description: str | None = None,
         arguments: list[dict[str, Any]] | None = None,
+        title: str | None = None,
+        icons: Any = None,
     ) -> Callable[[SyncOrAsyncCallable], SyncOrAsyncCallable] | SyncOrAsyncCallable:
         if func is None:
             return lambda callback: self.register(
@@ -437,6 +468,8 @@ class PromptRegistry(_RegistryBase):
                 name=name,
                 description=description,
                 arguments=arguments,
+                title=title,
+                icons=icons,
             )
 
         manager = get_current_registry_manager()
@@ -446,6 +479,8 @@ class PromptRegistry(_RegistryBase):
                 name=name,
                 description=description,
                 arguments=arguments,
+                title=title,
+                icons=icons,
             )
 
         prompt_name = name or func.__name__
@@ -455,6 +490,8 @@ class PromptRegistry(_RegistryBase):
             description=prompt_description,
             arguments=arguments if arguments is not None else _arguments_from_signature(func),
             function=func,
+            title=title,
+            icons=_normalize_tool_icons(icons),
         )
         self._prompts[prompt_name] = definition
         self._notify_listeners()
@@ -505,6 +542,10 @@ class ResourceRegistry(_RegistryBase):
         name: str | None = None,
         description: str | None = None,
         mime_type: str = "text/plain",
+        title: str | None = None,
+        icons: Any = None,
+        annotations: Any = None,
+        size: int | None = None,
     ) -> Callable[[SyncOrAsyncCallable], SyncOrAsyncCallable] | SyncOrAsyncCallable:
         if func is None:
             return lambda callback: self.register(
@@ -513,6 +554,10 @@ class ResourceRegistry(_RegistryBase):
                 name=name,
                 description=description,
                 mime_type=mime_type,
+                title=title,
+                icons=icons,
+                annotations=annotations,
+                size=size,
             )
 
         manager = get_current_registry_manager()
@@ -523,6 +568,10 @@ class ResourceRegistry(_RegistryBase):
                 name=name,
                 description=description,
                 mime_type=mime_type,
+                title=title,
+                icons=icons,
+                annotations=annotations,
+                size=size,
             )
 
         resource_name = name or func.__name__
@@ -533,6 +582,10 @@ class ResourceRegistry(_RegistryBase):
             description=resource_description,
             mime_type=mime_type,
             function=func,
+            title=title,
+            icons=_normalize_tool_icons(icons),
+            annotations=_normalize_tool_annotations(annotations),
+            size=size,
         )
         self._resources[uri] = definition
         self._notify_listeners()
@@ -547,6 +600,9 @@ class ResourceRegistry(_RegistryBase):
         description: str | None = None,
         mime_type: str = "text/plain",
         variables: dict[str, dict[str, Any]] | None = None,
+        title: str | None = None,
+        icons: Any = None,
+        annotations: Any = None,
     ) -> Callable[[SyncOrAsyncCallable], SyncOrAsyncCallable] | SyncOrAsyncCallable:
         if func is None:
             return lambda callback: self.register_template(
@@ -556,6 +612,9 @@ class ResourceRegistry(_RegistryBase):
                 description=description,
                 mime_type=mime_type,
                 variables=variables,
+                title=title,
+                icons=icons,
+                annotations=annotations,
             )
 
         manager = get_current_registry_manager()
@@ -567,6 +626,9 @@ class ResourceRegistry(_RegistryBase):
                 description=description,
                 mime_type=mime_type,
                 variables=variables,
+                title=title,
+                icons=icons,
+                annotations=annotations,
             )
 
         template_name = name or func.__name__
@@ -578,6 +640,9 @@ class ResourceRegistry(_RegistryBase):
             mime_type=mime_type,
             function=func,
             variables=variables,
+            title=title,
+            icons=_normalize_tool_icons(icons),
+            annotations=_normalize_tool_annotations(annotations),
         )
         signature = inspect.signature(func)
         available = set(definition._matcher.groupindex)

--- a/tests/unit/test_prompt_resource_metadata.py
+++ b/tests/unit/test_prompt_resource_metadata.py
@@ -1,0 +1,54 @@
+"""Tests for prompt and resource declaration metadata."""
+
+from pymcp.registry import PromptRegistry, ResourceRegistry
+
+
+def test_prompt_registry_emits_title_and_icons():
+    registry = PromptRegistry()
+
+    @registry.register(
+        title="Greeting Prompt",
+        icons=[{"src": "https://example.com/prompt.svg", "theme": "light"}],
+    )
+    def greeting(name: str) -> str:
+        return f"Hello, {name}!"
+
+    payload = registry.list_payload()[0]
+    assert payload["title"] == "Greeting Prompt"
+    assert payload["icons"][0]["theme"] == "light"
+
+
+def test_resource_registry_emits_extended_metadata():
+    registry = ResourceRegistry()
+
+    @registry.register(
+        uri="test://resource",
+        name="resource",
+        title="Resource Title",
+        icons=[{"src": "https://example.com/resource.svg", "theme": "dark"}],
+        annotations={"priority": 0.5},
+        size=42,
+    )
+    def resource() -> str:
+        return "payload"
+
+    @registry.register_template(
+        uri_template="test://items/{id}",
+        name="items",
+        title="Item Template",
+        icons=[{"src": "https://example.com/template.svg"}],
+        annotations={"audience": ["user"]},
+    )
+    def item(id: str) -> str:
+        return id
+
+    resource_payload = registry.list_payload()[0]
+    assert resource_payload["title"] == "Resource Title"
+    assert resource_payload["icons"][0]["theme"] == "dark"
+    assert resource_payload["annotations"]["priority"] == 0.5
+    assert resource_payload["size"] == 42
+
+    template_payload = registry.list_template_payload()[0]
+    assert template_payload["title"] == "Item Template"
+    assert template_payload["icons"][0]["src"] == "https://example.com/template.svg"
+    assert template_payload["annotations"]["audience"] == ["user"]


### PR DESCRIPTION
Covers the prompt/resource metadata box from issue #24.

This branch adds registry support and payload serialization for:
- prompt title and icons
- resource and resource-template title, icons, annotations, and size where applicable

Validation:
- PYTHONPYCACHEPREFIX=/tmp/pycache /Users/proshan/py-mcp/.venv/bin/pytest tests/unit/test_prompt_resource_metadata.py -q