### PR TITLE
Add MCP conformance badge, docs, and progress tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python CI](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/python-ci.yml/badge.svg)](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/python-ci.yml)
 [![codecov](https://codecov.io/gh/Agent-Hellboy/py-mcp/graph/badge.svg)](https://codecov.io/gh/Agent-Hellboy/py-mcp)
-[![MCP Conformance](https://img.shields.io/badge/MCP%20spec-2025--11--25%20conformant-brightgreen.svg)](https://modelcontextprotocol.io/specification/2025-11-25)
+[![MCP Conformance](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/conformance.yml/badge.svg)](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/conformance.yml)
 [![PyPI - Version](https://img.shields.io/pypi/v/pymcp-kit.svg)](https://pypi.org/project/pymcp-kit/)
 [![PyPI Downloads](https://static.pepy.tech/badge/pymcp-kit)](https://pepy.tech/projects/pymcp-kit)
 [![Docs](https://img.shields.io/badge/docs-github%20pages-0f766e.svg)](https://agent-hellboy.github.io/py-mcp/)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Python CI](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/python-ci.yml/badge.svg)](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/python-ci.yml)
 [![codecov](https://codecov.io/gh/Agent-Hellboy/py-mcp/graph/badge.svg)](https://codecov.io/gh/Agent-Hellboy/py-mcp)
+[![MCP Conformance](https://img.shields.io/badge/MCP%20spec-2025--11--25%20conformant-brightgreen.svg)](https://modelcontextprotocol.io/specification/2025-11-25)
 [![PyPI - Version](https://img.shields.io/pypi/v/pymcp-kit.svg)](https://pypi.org/project/pymcp-kit/)
 [![PyPI Downloads](https://static.pepy.tech/badge/pymcp-kit)](https://pepy.tech/projects/pymcp-kit)
 [![Docs](https://img.shields.io/badge/docs-github%20pages-0f766e.svg)](https://agent-hellboy.github.io/py-mcp/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python CI](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/python-ci.yml/badge.svg)](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/python-ci.yml)
 [![codecov](https://codecov.io/gh/Agent-Hellboy/py-mcp/graph/badge.svg)](https://codecov.io/gh/Agent-Hellboy/py-mcp)
-[![MCP Conformance](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/conformance.yml/badge.svg)](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/conformance.yml)
+[![MCP Conformance](https://github.com/Agent-Hellboy/py-mcp/actions/workflows/conformance.yml/badge.svg)](https://modelcontextprotocol.io/specification/2025-11-25)
 [![PyPI - Version](https://img.shields.io/pypi/v/pymcp-kit.svg)](https://pypi.org/project/pymcp-kit/)
 [![PyPI Downloads](https://static.pepy.tech/badge/pymcp-kit)](https://pepy.tech/projects/pymcp-kit)
 [![Docs](https://img.shields.io/badge/docs-github%20pages-0f766e.svg)](https://agent-hellboy.github.io/py-mcp/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,14 @@ Add bearer-token authentication and rule-based authorization without turning the
 
 </div>
 
+<div class="pymcp-card" markdown>
+
+### Spec conformant
+
+Passes the official [MCP conformance suite](https://github.com/modelcontextprotocol/conformance) in full against the [2025-11-25 spec](https://modelcontextprotocol.io/specification/2025-11-25), verified in CI on every change.
+
+</div>
+
 </div>
 
 ## Quick Install

--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -11,6 +11,16 @@
 - `2025-03-26`
 - `2024-11-05`
 
+## Conformance
+
+`pymcp-kit` passes the official [MCP conformance suite](https://github.com/modelcontextprotocol/conformance)
+in full against the [2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25).
+The suite runs in CI on every change (the `MCP Conformance` workflow) against the
+fixture server in `tests/conformance_server.py`, covering tool content blocks
+(text, image, audio, embedded, and mixed resources), tool errors, progress,
+logging, sampling, elicitation (including SEP-1034 defaults and SEP-1330 enum
+variants), resource reads/templates/subscriptions, and prompt retrieval.
+
 ## Built-In HTTP Endpoints
 
 - `GET /`: basic server metadata
@@ -41,6 +51,21 @@ Tool registration supports optional declaration metadata:
 
 Tool handlers may return `structuredContent` alongside `content` blocks in `tools/call` results.
 
+A tool can also accept a `request_context` parameter to report progress. When the
+client includes `_meta.progressToken` on the `tools/call` request, `report_progress`
+emits `notifications/progress`; otherwise it is a no-op.
+
+```python
+from pymcp import tool_registry
+from pymcp.runtime.context import RequestContext
+
+@tool_registry.register(title="Long job")
+async def longJobTool(request_context: RequestContext) -> dict:
+    await request_context.report_progress(0, 100)
+    await request_context.report_progress(100, 100, message="done")
+    return {"content": [{"type": "text", "text": "complete"}]}
+```
+
 ```python
 from pymcp import tool_registry
 
@@ -70,6 +95,10 @@ def addNumbersTool(a: float, b: float) -> dict:
 - `resources/subscribe`
 - `resources/unsubscribe`
 - `notifications/resources/updated`
+
+`resources/subscribe` and `resources/unsubscribe` return an empty result (`{}`)
+per the spec; subscription state is observable through
+`notifications/resources/updated`, not the response body.
 
 ### Roots (Client Capability)
 

--- a/tests/unit/test_tool_progress_notifications.py
+++ b/tests/unit/test_tool_progress_notifications.py
@@ -1,0 +1,117 @@
+"""Tests for progress notifications surfaced to tools via RequestContext.
+
+Tools must be registered before ``create_app`` since the app copies the global
+registries at creation time.
+"""
+
+import json
+
+import pytest
+
+from pymcp import create_app, tool_registry
+from pymcp.runtime.context import AppContext, RequestContext, SessionContext
+from pymcp.runtime.dispatch import process_jsonrpc_message
+from pymcp.session import get_session_manager
+from tests.support import initialize_ready_session
+
+pytestmark = pytest.mark.anyio
+
+
+def _drain(queue) -> list[dict]:
+    messages: list[dict] = []
+    while not queue.empty():
+        messages.append(json.loads(queue.get_nowait()))
+    return messages
+
+
+async def _ready_session_with_stream(app):
+    session = await initialize_ready_session(app)
+    await get_session_manager(app).note_stream_open(session.session_id, stream_id="stream-1")
+    return session
+
+
+async def _call_tool(app, session, name, *, meta=None):
+    params = {"name": name, "arguments": {}}
+    if meta is not None:
+        params["_meta"] = meta
+    await process_jsonrpc_message(
+        session.session_id,
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": params},
+        app=app,
+        direct_response=True,
+    )
+
+
+async def test_tools_call_emits_progress_for_request_token():
+    @tool_registry.register(name="progress_tool")
+    async def progress_tool(request_context: RequestContext) -> dict:
+        await request_context.report_progress(0, 100)
+        await request_context.report_progress(100, 100, message="done")
+        return {"content": [{"type": "text", "text": "ok"}]}
+
+    app = create_app(middleware_config=None)
+    session = await _ready_session_with_stream(app)
+    await _call_tool(app, session, "progress_tool", meta={"progressToken": "pt-x"})
+
+    progress = [m for m in _drain(session.queue) if m.get("method") == "notifications/progress"]
+    assert len(progress) == 2
+    assert progress[0]["params"] == {"progressToken": "pt-x", "progress": 0, "total": 100}
+    assert progress[1]["params"]["progress"] == 100
+    assert progress[1]["params"]["message"] == "done"
+
+
+async def test_tools_call_without_token_sends_no_progress():
+    @tool_registry.register(name="quiet_tool")
+    async def quiet_tool(request_context: RequestContext) -> dict:
+        assert request_context.progress_token is None
+        await request_context.report_progress(50, 100)
+        return {"content": [{"type": "text", "text": "ok"}]}
+
+    app = create_app(middleware_config=None)
+    session = await _ready_session_with_stream(app)
+    await _call_tool(app, session, "quiet_tool")
+
+    progress = [m for m in _drain(session.queue) if m.get("method") == "notifications/progress"]
+    assert progress == []
+
+
+async def test_tools_call_preserves_integer_progress_token():
+    @tool_registry.register(name="int_token_tool")
+    async def int_token_tool(request_context: RequestContext) -> dict:
+        await request_context.report_progress(1, 2)
+        return {"content": [{"type": "text", "text": "ok"}]}
+
+    app = create_app(middleware_config=None)
+    session = await _ready_session_with_stream(app)
+    await _call_tool(app, session, "int_token_tool", meta={"progressToken": 7})
+
+    progress = [m for m in _drain(session.queue) if m.get("method") == "notifications/progress"]
+    assert len(progress) == 1
+    assert progress[0]["params"]["progressToken"] == 7
+
+
+async def test_request_context_report_progress_noop_without_token():
+    app = create_app(middleware_config=None)
+    session = await _ready_session_with_stream(app)
+    ctx = RequestContext(
+        app_context=AppContext(app),
+        session_context=SessionContext(session.session_id),
+    )
+
+    assert ctx.app is app
+    assert ctx.session_id == session.session_id
+
+    await ctx.report_progress(10, 100)
+    assert _drain(session.queue) == []
+
+
+async def test_request_context_report_progress_noop_for_missing_session():
+    app = create_app(middleware_config=None)
+    ctx = RequestContext(
+        app_context=AppContext(app),
+        session_context=SessionContext("does-not-exist"),
+        progress_token="pt-y",
+    )
+
+    # Should not raise even though the session cannot be found.
+    await ctx.report_progress(10, 100)


### PR DESCRIPTION
## Summary
Follow-up to #29 (full MCP conformance suite now passing). This PR surfaces the conformance status and improves coverage of the new runtime code.

- **README badge** advertising 2025-11-25 spec conformance, linking to the spec.
- **Docs**: a Conformance section in the Runtime Surface page, a "Spec conformant" feature card on the home page, plus documentation for tool progress reporting (`RequestContext.report_progress`) and the empty-result shape of `resources/subscribe` / `resources/unsubscribe`.
- **Tests**: unit coverage for progress notifications surfaced to tools — both the `RequestContext.report_progress` helper and the `tools/call` `progressToken` wiring. `pymcp/runtime/context.py` goes 54% → 100%.

## Verification
- `pytest tests/`: 207 passed
- `ruff check`: clean
- `mkdocs build --strict`: builds clean