### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/pymcp/settings.py
+++ b/pymcp/settings.py
@@ -43,7 +43,7 @@ class CapabilitySettings:
 @dataclass(slots=True)
 class ServerSettings:
     name: str = "pymcp-kit"
-    version: str = "0.1.0"
+    version: str = "0.2.0"
     protocol_versions: tuple[str, ...] = SUPPORTED_PROTOCOL_VERSIONS
     capabilities: CapabilitySettings = field(default_factory=CapabilitySettings)
     title: str | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymcp-kit"
-version = "0.1.0"
+version = "0.2.0"
 description = "A capability-first MCP server toolkit for FastAPI with Streamable HTTP and stdio transport"
 authors = [
     { name = "Prince Roshan", email = "princekrroshan01@gmail.com" }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,11 +38,11 @@ def test_default_server_settings_flow_into_initialize_and_root():
     assert response.status_code == 200
     root_payload = response.json()
     assert root_payload["server"]["name"] == "pymcp-kit"
-    assert root_payload["server"]["version"] == "0.1.0"
+    assert root_payload["server"]["version"] == "0.2.0"
 
     _, body = _initialize_session(client)
     assert body["result"]["serverInfo"]["name"] == "pymcp-kit"
-    assert body["result"]["serverInfo"]["version"] == "0.1.0"
+    assert body["result"]["serverInfo"]["version"] == "0.2.0"
 
 
 def test_custom_server_settings_include_optional_metadata():


### PR DESCRIPTION
Release prep for v0.2.0.

- `pyproject.toml` version 0.1.0 -> 0.2.0 (must match the `v0.2.0` tag for the publish workflow)
- `ServerSettings` default version -> 0.2.0
- Update default-version assertions in `tests/test_server.py`

Tagging `v0.2.0` after this merges triggers the PyPI publish.